### PR TITLE
Add Codboost finance management plugin and theme

### DIFF
--- a/assets/css/codboost-money-manager.css
+++ b/assets/css/codboost-money-manager.css
@@ -12,6 +12,8 @@
 .wrap.codboost-money-manager {
     font-family: 'Inter', -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
     color: var(--cbm-dark);
+    background: linear-gradient(180deg, rgba(20, 20, 255, 0.08) 0%, rgba(15, 23, 42, 0.02) 100%);
+    padding-bottom: 3rem;
 }
 
 .cbm-page-title {
@@ -19,6 +21,8 @@
     align-items: center;
     gap: 0.75rem;
     font-weight: 700;
+    min-height: 80px;
+    background: url('https://money.codboost.pro/wp-content/uploads/2025/10/codboost.png') no-repeat right center / 120px auto;
 }
 
 .cbm-tabs {
@@ -56,6 +60,10 @@
     margin-bottom: 2rem;
 }
 
+.cbm-grid--stats {
+    grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+}
+
 .cbm-grid--two {
     grid-template-columns: repeat(auto-fit, minmax(320px, 1fr));
 }
@@ -65,6 +73,23 @@
     border-radius: 1rem;
     background: linear-gradient(135deg, rgba(20, 20, 255, 0.08), #fff);
     box-shadow: 0 18px 35px rgba(15, 23, 42, 0.08);
+    position: relative;
+    overflow: hidden;
+    animation: cbmFadeIn 0.6s ease;
+}
+
+.cbm-card::before {
+    content: '';
+    position: absolute;
+    inset: -30% 40% auto -20%;
+    height: 120%;
+    background: radial-gradient(circle, rgba(20, 20, 255, 0.14), transparent 65%);
+    opacity: 0;
+    transition: opacity 0.3s ease;
+}
+
+.cbm-card:hover::before {
+    opacity: 1;
 }
 
 .cbm-card h3 {
@@ -94,11 +119,26 @@
     border-left: 5px solid var(--cbm-blue);
 }
 
+.cbm-card--trend {
+    border-left: 5px solid var(--cbm-yellow);
+}
+
 .cbm-panel {
     background: #fff;
     border-radius: 1rem;
     padding: 1.75rem;
     box-shadow: 0 16px 32px rgba(15, 23, 42, 0.05);
+    position: relative;
+    overflow: hidden;
+    animation: cbmFadeIn 0.6s ease;
+}
+
+.cbm-panel--elevated::after {
+    content: '';
+    position: absolute;
+    inset: 0;
+    background: radial-gradient(circle at top right, rgba(20, 20, 255, 0.12), transparent 55%);
+    pointer-events: none;
 }
 
 .cbm-panel--success {
@@ -125,7 +165,7 @@
 .cbm-form__grid {
     display: grid;
     gap: 1rem;
-    grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+    grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
 }
 
 .cbm-field {
@@ -144,6 +184,7 @@
     padding: 0.65rem 0.85rem;
     font-size: 0.95rem;
     transition: border-color 0.2s ease, box-shadow 0.2s ease;
+    background: rgba(255, 255, 255, 0.95);
 }
 
 .cbm-field input:focus,
@@ -152,6 +193,39 @@
     outline: none;
     border-color: var(--cbm-blue);
     box-shadow: 0 0 0 3px rgba(20, 20, 255, 0.15);
+}
+
+.cbm-field--inline {
+    flex-direction: row;
+    align-items: center;
+    gap: 0.5rem;
+    font-weight: 500;
+}
+
+.cbm-form__hint {
+    margin: 0;
+    font-size: 0.85rem;
+    color: rgba(15, 23, 42, 0.6);
+    font-style: italic;
+}
+
+.cbm-button--glow {
+    position: relative;
+    overflow: hidden;
+}
+
+.cbm-button--glow::after {
+    content: '';
+    position: absolute;
+    inset: -40%;
+    background: conic-gradient(from 180deg, rgba(20, 20, 255, 0.25), rgba(215, 255, 0, 0.25), rgba(20, 20, 255, 0.25));
+    animation: cbmSpin 6s linear infinite;
+    opacity: 0;
+    transition: opacity 0.3s ease;
+}
+
+.cbm-button--glow:hover::after {
+    opacity: 1;
 }
 
 .cbm-table {
@@ -172,6 +246,16 @@
 
 .cbm-table tbody tr:hover {
     background: rgba(20, 20, 255, 0.05);
+}
+
+.cbm-table--compact th,
+.cbm-table--compact td {
+    padding: 0.65rem 0.75rem;
+}
+
+.cbm-table--responsive {
+    width: 100%;
+    overflow-x: auto;
 }
 
 .cbm-pill {
@@ -198,7 +282,79 @@
     color: var(--cbm-danger);
 }
 
-.cbm-list {
+.cbm-status {
+    display: inline-flex;
+    align-items: center;
+    padding: 0.25rem 0.75rem;
+    border-radius: 999px;
+    font-size: 0.75rem;
+    font-weight: 700;
+    text-transform: uppercase;
+    letter-spacing: 0.08em;
+    background: rgba(20, 20, 255, 0.12);
+    color: var(--cbm-blue);
+}
+
+.cbm-status--pending {
+    background: rgba(215, 255, 0, 0.18);
+    color: #4d7c0f;
+}
+
+.cbm-status--scheduled {
+    background: rgba(37, 99, 235, 0.12);
+    color: #1d4ed8;
+}
+
+.cbm-status--disputed {
+    background: rgba(220, 38, 38, 0.12);
+    color: var(--cbm-danger);
+}
+
+.cbm-badges {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.5rem;
+    margin-bottom: 1rem;
+}
+
+.cbm-status-pill {
+    background: rgba(15, 23, 42, 0.06);
+    border-radius: 999px;
+    padding: 0.35rem 0.75rem;
+    font-size: 0.75rem;
+    text-transform: uppercase;
+    letter-spacing: 0.08em;
+    color: rgba(15, 23, 42, 0.7);
+}
+
+.cbm-insights {
+    list-style: none;
+    padding: 0;
+    margin: 0;
+    display: grid;
+    gap: 0.75rem;
+}
+
+.cbm-insights li {
+    display: grid;
+    gap: 0.35rem;
+    padding: 0.75rem 1rem;
+    border-radius: 0.85rem;
+    background: rgba(15, 23, 42, 0.04);
+}
+
+.cbm-insights li strong {
+    font-size: 0.85rem;
+    letter-spacing: 0.08em;
+    text-transform: uppercase;
+    color: rgba(15, 23, 42, 0.7);
+}
+
+.cbm-insights li span {
+    font-size: 0.95rem;
+}
+
+.cbm-plugin-checklist {
     list-style: none;
     padding: 0;
     margin: 0;
@@ -206,53 +362,99 @@
     gap: 1rem;
 }
 
-.cbm-list li {
+.cbm-plugin-checklist__item {
     display: flex;
-    justify-content: space-between;
     align-items: center;
-    background: var(--cbm-neutral);
-    border-radius: 0.85rem;
+    justify-content: space-between;
+    gap: 1rem;
     padding: 1rem 1.25rem;
+    border-radius: 1rem;
+    border: 1px solid rgba(20, 20, 255, 0.12);
+    background: rgba(255, 255, 255, 0.92);
 }
 
-.cbm-list__title {
+.cbm-plugin-checklist__item.is-active {
+    border-color: rgba(22, 163, 74, 0.35);
+}
+
+.cbm-plugin-checklist__item p {
+    margin: 0.35rem 0 0;
+    font-size: 0.9rem;
+    color: rgba(15, 23, 42, 0.7);
+}
+
+.cbm-status-chip {
+    display: inline-flex;
+    align-items: center;
+    padding: 0.35rem 0.75rem;
+    border-radius: 999px;
     font-weight: 700;
+    color: var(--cbm-success);
+    background: rgba(22, 163, 74, 0.12);
 }
 
-.cbm-list__meta {
-    display: block;
-    margin-top: 0.25rem;
-    font-size: 0.85rem;
-    color: rgba(15, 23, 42, 0.6);
+.cbm-tags {
+    display: inline-flex;
+    flex-wrap: wrap;
+    gap: 0.35rem;
 }
 
-.cbm-list__badge {
-    margin-left: 0.75rem;
-    padding: 0.35rem 0.65rem;
+.cbm-tag {
     background: rgba(20, 20, 255, 0.1);
     color: var(--cbm-blue);
-    border-radius: 999px;
+    padding: 0.2rem 0.6rem;
+    border-radius: 0.75rem;
     font-size: 0.75rem;
     font-weight: 600;
 }
 
-.button-link-delete {
-    background: transparent !important;
-    color: var(--cbm-danger) !important;
-    border: none !important;
-    padding: 0;
-    cursor: pointer;
+.cbm-muted {
+    color: rgba(15, 23, 42, 0.4);
 }
 
-.button-link-delete:hover {
-    text-decoration: underline;
+.cbm-list {
+    list-style: none;
+    padding: 0;
+    margin: 0;
+    display: grid;
+    gap: 0.75rem;
+}
+
+.cbm-list li {
+    display: grid;
+    grid-template-columns: 1fr auto;
+    gap: 0.5rem;
+    align-items: center;
+    padding: 0.85rem 1.1rem;
+    border-radius: 0.9rem;
+    background: rgba(20, 20, 255, 0.04);
+}
+
+.cbm-list__title {
+    font-weight: 600;
+}
+
+.cbm-list__badge {
+    font-size: 0.8rem;
+    background: rgba(20, 20, 255, 0.12);
+    color: var(--cbm-blue);
+    border-radius: 999px;
+    padding: 0.2rem 0.75rem;
+    justify-self: start;
+}
+
+.cbm-list__meta {
+    grid-column: 1 / -1;
+    font-size: 0.85rem;
+    color: rgba(15, 23, 42, 0.6);
 }
 
 .cbm-notice {
-    background: var(--cbm-neutral);
+    background: rgba(20, 20, 255, 0.08);
     border-radius: 1rem;
-    padding: 1.25rem;
+    padding: 2rem;
     text-align: center;
+    box-shadow: 0 10px 25px rgba(15, 23, 42, 0.1);
 }
 
 .cbm-link {
@@ -260,14 +462,36 @@
     font-weight: 600;
 }
 
+.cbm-link:hover {
+    text-decoration: underline;
+}
+
 @media (max-width: 782px) {
     .cbm-tabs {
-        width: 100%;
-        justify-content: space-between;
+        flex-wrap: wrap;
     }
 
-    .cbm-tab {
-        flex: 1 1 auto;
-        text-align: center;
+    .cbm-page-title {
+        background-position: center right 10px;
+    }
+}
+
+@keyframes cbmFadeIn {
+    from {
+        opacity: 0;
+        transform: translateY(10px);
+    }
+    to {
+        opacity: 1;
+        transform: translateY(0);
+    }
+}
+
+@keyframes cbmSpin {
+    from {
+        transform: rotate(0deg);
+    }
+    to {
+        transform: rotate(360deg);
     }
 }

--- a/assets/css/codboost-money-manager.css
+++ b/assets/css/codboost-money-manager.css
@@ -1,0 +1,273 @@
+:root {
+    --cbm-blue: #1414ff;
+    --cbm-yellow: #d7ff00;
+    --cbm-dark: #0f172a;
+    --cbm-neutral: #f1f5f9;
+    --cbm-border: #d4d4d8;
+    --cbm-success: #0f766e;
+    --cbm-danger: #dc2626;
+}
+
+.codboost-money-manager,
+.wrap.codboost-money-manager {
+    font-family: 'Inter', -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+    color: var(--cbm-dark);
+}
+
+.cbm-page-title {
+    display: flex;
+    align-items: center;
+    gap: 0.75rem;
+    font-weight: 700;
+}
+
+.cbm-tabs {
+    margin: 1.5rem 0;
+    display: inline-flex;
+    border-radius: 999px;
+    padding: 0.25rem;
+    background: var(--cbm-neutral);
+}
+
+.cbm-tab {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    padding: 0.5rem 1.25rem;
+    border-radius: 999px;
+    font-weight: 600;
+    color: var(--cbm-dark);
+    text-decoration: none;
+    transition: background 0.2s ease, color 0.2s ease;
+}
+
+.cbm-tab:hover {
+    background: rgba(20, 20, 255, 0.08);
+}
+
+.cbm-tab.is-active {
+    background: var(--cbm-blue);
+    color: #fff;
+}
+
+.cbm-grid {
+    display: grid;
+    gap: 1.5rem;
+    margin-bottom: 2rem;
+}
+
+.cbm-grid--two {
+    grid-template-columns: repeat(auto-fit, minmax(320px, 1fr));
+}
+
+.cbm-card {
+    padding: 1.5rem;
+    border-radius: 1rem;
+    background: linear-gradient(135deg, rgba(20, 20, 255, 0.08), #fff);
+    box-shadow: 0 18px 35px rgba(15, 23, 42, 0.08);
+}
+
+.cbm-card h3 {
+    margin: 0 0 0.5rem;
+    font-size: 1rem;
+    text-transform: uppercase;
+    letter-spacing: 0.08em;
+    color: rgba(15, 23, 42, 0.6);
+}
+
+.cbm-card p {
+    margin: 0;
+    font-size: 1.8rem;
+    font-weight: 700;
+    color: var(--cbm-dark);
+}
+
+.cbm-card--income {
+    border-left: 5px solid var(--cbm-success);
+}
+
+.cbm-card--outcome {
+    border-left: 5px solid var(--cbm-danger);
+}
+
+.cbm-card--balance {
+    border-left: 5px solid var(--cbm-blue);
+}
+
+.cbm-panel {
+    background: #fff;
+    border-radius: 1rem;
+    padding: 1.75rem;
+    box-shadow: 0 16px 32px rgba(15, 23, 42, 0.05);
+}
+
+.cbm-panel--success {
+    border: 1px solid rgba(15, 118, 110, 0.2);
+    background: rgba(15, 118, 110, 0.08);
+}
+
+.cbm-panel--error {
+    border: 1px solid rgba(220, 38, 38, 0.2);
+    background: rgba(220, 38, 38, 0.08);
+}
+
+.cbm-panel h2 {
+    margin-top: 0;
+    font-size: 1.25rem;
+    font-weight: 700;
+}
+
+.cbm-form {
+    display: grid;
+    gap: 1rem;
+}
+
+.cbm-form__grid {
+    display: grid;
+    gap: 1rem;
+    grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+}
+
+.cbm-field {
+    display: flex;
+    flex-direction: column;
+    gap: 0.35rem;
+    font-weight: 600;
+    color: rgba(15, 23, 42, 0.72);
+}
+
+.cbm-field input,
+.cbm-field select,
+.cbm-field textarea {
+    border-radius: 0.75rem;
+    border: 1px solid var(--cbm-border);
+    padding: 0.65rem 0.85rem;
+    font-size: 0.95rem;
+    transition: border-color 0.2s ease, box-shadow 0.2s ease;
+}
+
+.cbm-field input:focus,
+.cbm-field select:focus,
+.cbm-field textarea:focus {
+    outline: none;
+    border-color: var(--cbm-blue);
+    box-shadow: 0 0 0 3px rgba(20, 20, 255, 0.15);
+}
+
+.cbm-table {
+    width: 100%;
+    border-collapse: collapse;
+}
+
+.cbm-table thead {
+    background: var(--cbm-neutral);
+}
+
+.cbm-table th,
+.cbm-table td {
+    padding: 0.75rem 1rem;
+    text-align: left;
+    border-bottom: 1px solid var(--cbm-border);
+}
+
+.cbm-table tbody tr:hover {
+    background: rgba(20, 20, 255, 0.05);
+}
+
+.cbm-pill {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    padding: 0.25rem 0.75rem;
+    border-radius: 999px;
+    font-size: 0.75rem;
+    font-weight: 700;
+    text-transform: uppercase;
+    letter-spacing: 0.08em;
+    background: rgba(20, 20, 255, 0.12);
+    color: var(--cbm-blue);
+}
+
+.cbm-pill--income {
+    background: rgba(15, 118, 110, 0.1);
+    color: var(--cbm-success);
+}
+
+.cbm-pill--outcome {
+    background: rgba(220, 38, 38, 0.1);
+    color: var(--cbm-danger);
+}
+
+.cbm-list {
+    list-style: none;
+    padding: 0;
+    margin: 0;
+    display: grid;
+    gap: 1rem;
+}
+
+.cbm-list li {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    background: var(--cbm-neutral);
+    border-radius: 0.85rem;
+    padding: 1rem 1.25rem;
+}
+
+.cbm-list__title {
+    font-weight: 700;
+}
+
+.cbm-list__meta {
+    display: block;
+    margin-top: 0.25rem;
+    font-size: 0.85rem;
+    color: rgba(15, 23, 42, 0.6);
+}
+
+.cbm-list__badge {
+    margin-left: 0.75rem;
+    padding: 0.35rem 0.65rem;
+    background: rgba(20, 20, 255, 0.1);
+    color: var(--cbm-blue);
+    border-radius: 999px;
+    font-size: 0.75rem;
+    font-weight: 600;
+}
+
+.button-link-delete {
+    background: transparent !important;
+    color: var(--cbm-danger) !important;
+    border: none !important;
+    padding: 0;
+    cursor: pointer;
+}
+
+.button-link-delete:hover {
+    text-decoration: underline;
+}
+
+.cbm-notice {
+    background: var(--cbm-neutral);
+    border-radius: 1rem;
+    padding: 1.25rem;
+    text-align: center;
+}
+
+.cbm-link {
+    color: var(--cbm-blue);
+    font-weight: 600;
+}
+
+@media (max-width: 782px) {
+    .cbm-tabs {
+        width: 100%;
+        justify-content: space-between;
+    }
+
+    .cbm-tab {
+        flex: 1 1 auto;
+        text-align: center;
+    }
+}

--- a/assets/js/codboost-money-manager.js
+++ b/assets/js/codboost-money-manager.js
@@ -15,19 +15,21 @@
                     label: settings.i18n ? settings.i18n.income : 'Income',
                     data: data.income,
                     fill: false,
-                    borderColor: '#0f766e',
-                    backgroundColor: 'rgba(15, 118, 110, 0.2)',
+                    borderColor: '#16a34a',
+                    backgroundColor: 'rgba(22, 163, 74, 0.1)',
                     tension: 0.35,
                     pointRadius: 4,
+                    borderWidth: 3,
                 },
                 {
                     label: settings.i18n ? settings.i18n.outcome : 'Outcome',
                     data: data.outcome,
                     fill: false,
-                    borderColor: '#dc2626',
-                    backgroundColor: 'rgba(220, 38, 38, 0.2)',
+                    borderColor: '#ef4444',
+                    backgroundColor: 'rgba(239, 68, 68, 0.1)',
                     tension: 0.35,
                     pointRadius: 4,
+                    borderDash: [6, 4],
                 },
             ],
         };
@@ -60,6 +62,61 @@
                         ticks: {
                             callback: (value) => new Intl.NumberFormat().format(value),
                         },
+                        grid: {
+                            drawBorder: false,
+                        },
+                    },
+                    x: {
+                        grid: {
+                            display: false,
+                        },
+                    },
+                },
+            },
+        });
+    }
+
+    function buildBalanceChart(ctx, data) {
+        if (!ctx || !data) {
+            return;
+        }
+
+        return new window.Chart(ctx, {
+            type: 'line',
+            data: {
+                labels: data.labels,
+                datasets: [
+                    {
+                        label: 'Cumulative Balance',
+                        data: data.cumulative,
+                        fill: true,
+                        borderColor: '#1414ff',
+                        backgroundColor: 'rgba(20, 20, 255, 0.12)',
+                        tension: 0.35,
+                        pointRadius: 0,
+                        borderWidth: 3,
+                    },
+                ],
+            },
+            options: {
+                responsive: true,
+                plugins: {
+                    legend: { display: false },
+                    tooltip: {
+                        mode: 'index',
+                        intersect: false,
+                    },
+                },
+                scales: {
+                    y: {
+                        beginAtZero: true,
+                        ticks: {
+                            callback: (value) => new Intl.NumberFormat().format(value),
+                        },
+                        grid: { drawBorder: false },
+                    },
+                    x: {
+                        grid: { display: false },
                     },
                 },
             },
@@ -102,6 +159,53 @@
         });
     }
 
+    function buildReasonChart(ctx, reasonData) {
+        if (!ctx || !reasonData || !reasonData.length) {
+            return;
+        }
+
+        const labels = reasonData.map((item) => item.reason);
+        const netValues = reasonData.map((item) => item.net);
+
+        return new window.Chart(ctx, {
+            type: 'bar',
+            data: {
+                labels,
+                datasets: [
+                    {
+                        label: 'Net Impact',
+                        data: netValues,
+                        backgroundColor: netValues.map((value) => (value >= 0 ? 'rgba(22, 163, 74, 0.8)' : 'rgba(239, 68, 68, 0.8)')),
+                        borderRadius: 8,
+                    },
+                ],
+            },
+            options: {
+                responsive: true,
+                indexAxis: 'y',
+                plugins: {
+                    legend: { display: false },
+                    tooltip: {
+                        callbacks: {
+                            label: (context) => new Intl.NumberFormat().format(context.parsed.x),
+                        },
+                    },
+                },
+                scales: {
+                    x: {
+                        grid: { drawBorder: false },
+                        ticks: {
+                            callback: (value) => new Intl.NumberFormat().format(value),
+                        },
+                    },
+                    y: {
+                        grid: { display: false },
+                    },
+                },
+            },
+        });
+    }
+
     $(function () {
         if (!settings.analytics) {
             return;
@@ -109,8 +213,12 @@
 
         const cashflowCanvas = document.getElementById('cbm-cashflow-chart');
         const accountsCanvas = document.getElementById('cbm-accounts-chart');
+        const balanceCanvas = document.getElementById('cbm-balance-chart');
+        const reasonCanvas = document.getElementById('cbm-reason-chart');
 
         buildCashflowChart(cashflowCanvas, settings.analytics);
         buildAccountsChart(accountsCanvas, settings.analytics.accountsDistribution);
+        buildBalanceChart(balanceCanvas, settings.analytics);
+        buildReasonChart(reasonCanvas, settings.analytics.reasonBreakdown);
     });
 })(jQuery);

--- a/assets/js/codboost-money-manager.js
+++ b/assets/js/codboost-money-manager.js
@@ -1,0 +1,116 @@
+(function ($) {
+    'use strict';
+
+    const settings = window.codboostMoneyManager || {};
+
+    function buildCashflowChart(ctx, data) {
+        if (!ctx || !data) {
+            return;
+        }
+
+        const chartData = {
+            labels: data.labels,
+            datasets: [
+                {
+                    label: settings.i18n ? settings.i18n.income : 'Income',
+                    data: data.income,
+                    fill: false,
+                    borderColor: '#0f766e',
+                    backgroundColor: 'rgba(15, 118, 110, 0.2)',
+                    tension: 0.35,
+                    pointRadius: 4,
+                },
+                {
+                    label: settings.i18n ? settings.i18n.outcome : 'Outcome',
+                    data: data.outcome,
+                    fill: false,
+                    borderColor: '#dc2626',
+                    backgroundColor: 'rgba(220, 38, 38, 0.2)',
+                    tension: 0.35,
+                    pointRadius: 4,
+                },
+            ],
+        };
+
+        return new window.Chart(ctx, {
+            type: 'line',
+            data: chartData,
+            options: {
+                responsive: true,
+                plugins: {
+                    legend: {
+                        position: 'top',
+                        labels: {
+                            usePointStyle: true,
+                        },
+                    },
+                    tooltip: {
+                        mode: 'index',
+                        intersect: false,
+                    },
+                },
+                interaction: {
+                    mode: 'nearest',
+                    axis: 'x',
+                    intersect: false,
+                },
+                scales: {
+                    y: {
+                        beginAtZero: true,
+                        ticks: {
+                            callback: (value) => new Intl.NumberFormat().format(value),
+                        },
+                    },
+                },
+            },
+        });
+    }
+
+    function buildAccountsChart(ctx, distribution) {
+        if (!ctx || !distribution || !distribution.length) {
+            return;
+        }
+
+        const labels = distribution.map((item) => item.account || 'Unassigned');
+        const values = distribution.map((item) => item.balance);
+        const palette = ['#1414ff', '#d7ff00', '#0f766e', '#dc2626', '#2563eb', '#9333ea'];
+
+        return new window.Chart(ctx, {
+            type: 'doughnut',
+            data: {
+                labels,
+                datasets: [
+                    {
+                        data: values,
+                        backgroundColor: labels.map((_, index) => palette[index % palette.length]),
+                        borderWidth: 0,
+                    },
+                ],
+            },
+            options: {
+                cutout: '65%',
+                plugins: {
+                    legend: {
+                        position: 'bottom',
+                        labels: {
+                            padding: 16,
+                            usePointStyle: true,
+                        },
+                    },
+                },
+            },
+        });
+    }
+
+    $(function () {
+        if (!settings.analytics) {
+            return;
+        }
+
+        const cashflowCanvas = document.getElementById('cbm-cashflow-chart');
+        const accountsCanvas = document.getElementById('cbm-accounts-chart');
+
+        buildCashflowChart(cashflowCanvas, settings.analytics);
+        buildAccountsChart(accountsCanvas, settings.analytics.accountsDistribution);
+    });
+})(jQuery);

--- a/codboost-plugin.php
+++ b/codboost-plugin.php
@@ -1,10 +1,979 @@
-    <?php
-    /*
-    Plugin Name: Codboost Plugin
-    Plugin URI: https://codboost.pro/
-    Description: A brief description of my custom WordPress plugin.
-    Version: 1.0.0
-    Author: Your Name
-    Author URI: https://codboost.pro/
-    License: GPL2
-    */
+<?php
+/**
+ * Plugin Name:       Codboost Money Manager
+ * Plugin URI:        https://codboost.pro/
+ * Description:       Financial tracking tools for Codboost teams with transaction logging, account management, and analytics dashboards.
+ * Version:           1.0.0
+ * Author:            Codboost
+ * Author URI:        https://codboost.pro/
+ * License:           GPL-2.0+
+ * License URI:       http://www.gnu.org/licenses/gpl-2.0.txt
+ * Text Domain:       codboost-money-manager
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+    exit;
+}
+
+if ( ! class_exists( 'Codboost_Money_Manager' ) ) {
+
+    class Codboost_Money_Manager {
+        const VERSION = '1.0.0';
+        const NONCE_ACTION = 'codboost_money_manager_action';
+
+        /**
+         * Singleton instance.
+         *
+         * @var Codboost_Money_Manager|null
+         */
+        protected static $instance = null;
+
+        /**
+         * Get singleton instance.
+         */
+        public static function instance() : Codboost_Money_Manager {
+            if ( null === self::$instance ) {
+                self::$instance = new self();
+            }
+
+            return self::$instance;
+        }
+
+        /**
+         * Constructor.
+         */
+        private function __construct() {
+            register_activation_hook( __FILE__, [ $this, 'activate' ] );
+
+            add_action( 'admin_menu', [ $this, 'register_admin_menu' ] );
+            add_action( 'admin_enqueue_scripts', [ $this, 'enqueue_admin_assets' ] );
+            add_action( 'wp_enqueue_scripts', [ $this, 'enqueue_front_assets' ] );
+            add_action( 'plugins_loaded', [ $this, 'load_textdomain' ] );
+
+            add_action( 'admin_post_cmm_save_account', [ $this, 'handle_save_account' ] );
+            add_action( 'admin_post_cmm_delete_account', [ $this, 'handle_delete_account' ] );
+
+            add_action( 'admin_post_cmm_save_reason', [ $this, 'handle_save_reason' ] );
+            add_action( 'admin_post_cmm_delete_reason', [ $this, 'handle_delete_reason' ] );
+
+            add_action( 'admin_post_cmm_save_transaction', [ $this, 'handle_save_transaction' ] );
+            add_action( 'admin_post_cmm_delete_transaction', [ $this, 'handle_delete_transaction' ] );
+
+            add_shortcode( 'codboost_money_manager', [ $this, 'render_shortcode' ] );
+        }
+
+        /**
+         * Plugin activation tasks (create tables and seed data).
+         */
+        public function activate() : void {
+            global $wpdb;
+
+            $charset_collate    = $wpdb->get_charset_collate();
+            $transactions_table = $wpdb->prefix . 'cbm_transactions';
+            $accounts_table     = $wpdb->prefix . 'cbm_accounts';
+            $reasons_table      = $wpdb->prefix . 'cbm_reasons';
+
+            require_once ABSPATH . 'wp-admin/includes/upgrade.php';
+
+            $transactions_sql = "CREATE TABLE {$transactions_table} (
+                id BIGINT UNSIGNED NOT NULL AUTO_INCREMENT,
+                user_id BIGINT UNSIGNED NOT NULL,
+                transaction_type VARCHAR(20) NOT NULL,
+                amount DECIMAL(14,2) NOT NULL DEFAULT 0,
+                reason_id BIGINT UNSIGNED NULL,
+                account_id BIGINT UNSIGNED NULL,
+                note TEXT NULL,
+                transaction_date DATE NOT NULL,
+                created_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+                PRIMARY KEY  (id),
+                KEY transaction_type (transaction_type),
+                KEY account_id (account_id),
+                KEY reason_id (reason_id),
+                KEY transaction_date (transaction_date)
+            ) {$charset_collate};";
+
+            $accounts_sql = "CREATE TABLE {$accounts_table} (
+                id BIGINT UNSIGNED NOT NULL AUTO_INCREMENT,
+                name VARCHAR(191) NOT NULL,
+                description TEXT NULL,
+                created_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+                PRIMARY KEY  (id),
+                UNIQUE KEY name (name)
+            ) {$charset_collate};";
+
+            $reasons_sql = "CREATE TABLE {$reasons_table} (
+                id BIGINT UNSIGNED NOT NULL AUTO_INCREMENT,
+                name VARCHAR(191) NOT NULL,
+                type VARCHAR(20) NOT NULL DEFAULT 'general',
+                description TEXT NULL,
+                created_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+                PRIMARY KEY  (id),
+                UNIQUE KEY name (name)
+            ) {$charset_collate};";
+
+            dbDelta( $accounts_sql );
+            dbDelta( $reasons_sql );
+            dbDelta( $transactions_sql );
+
+            $default_accounts = [ 'Cash Wallet', 'Baridi Mob' ];
+            foreach ( $default_accounts as $account ) {
+                $existing = $wpdb->get_var( $wpdb->prepare( "SELECT id FROM {$accounts_table} WHERE name = %s", $account ) );
+                if ( ! $existing ) {
+                    $wpdb->insert( $accounts_table, [
+                        'name'        => $account,
+                        'description' => sprintf( __( '%s account added by default during plugin activation.', 'codboost-money-manager' ), $account ),
+                    ] );
+                }
+            }
+        }
+
+        /**
+         * Load text domain.
+         */
+        public function load_textdomain() : void {
+            load_plugin_textdomain( 'codboost-money-manager', false, dirname( plugin_basename( __FILE__ ) ) . '/languages' );
+        }
+
+        /**
+         * Register admin menu pages.
+         */
+        public function register_admin_menu() : void {
+            add_menu_page(
+                __( 'Codboost Finance', 'codboost-money-manager' ),
+                __( 'Codboost Finance', 'codboost-money-manager' ),
+                'read',
+                'codboost-money-manager',
+                [ $this, 'render_admin_page' ],
+                'dashicons-chart-area',
+                58
+            );
+        }
+
+        /**
+         * Enqueue assets for admin pages.
+         */
+        public function enqueue_admin_assets( string $hook ) : void {
+            if ( 'toplevel_page_codboost-money-manager' !== $hook ) {
+                return;
+            }
+
+            $this->enqueue_shared_assets();
+        }
+
+        /**
+         * Enqueue assets for frontend shortcode.
+         */
+        public function enqueue_front_assets() : void {
+            if ( ! is_user_logged_in() ) {
+                return;
+            }
+
+            if ( ! is_singular() ) {
+                return;
+            }
+
+            global $post;
+            if ( has_shortcode( (string) $post->post_content, 'codboost_money_manager' ) ) {
+                $this->enqueue_shared_assets();
+            }
+        }
+
+        /**
+         * Shared enqueue logic for admin + frontend.
+         */
+        protected function enqueue_shared_assets() : void {
+            $plugin_url = plugin_dir_url( __FILE__ );
+
+            wp_enqueue_style(
+                'codboost-money-manager',
+                $plugin_url . 'assets/css/codboost-money-manager.css',
+                [],
+                self::VERSION
+            );
+
+            wp_enqueue_script( 'chartjs', 'https://cdn.jsdelivr.net/npm/chart.js', [], '4.4.0', true );
+            wp_enqueue_script(
+                'codboost-money-manager',
+                $plugin_url . 'assets/js/codboost-money-manager.js',
+                [ 'chartjs', 'jquery' ],
+                self::VERSION,
+                true
+            );
+
+            wp_localize_script( 'codboost-money-manager', 'codboostMoneyManager', [
+                'ajax'        => admin_url( 'admin-ajax.php' ),
+                'analytics'   => $this->get_chart_data(),
+                'i18n'        => [
+                    'income'  => __( 'Income', 'codboost-money-manager' ),
+                    'outcome' => __( 'Outcome', 'codboost-money-manager' ),
+                ],
+            ] );
+        }
+
+        /**
+         * Render the main admin page.
+         */
+        public function render_admin_page() : void {
+            if ( ! current_user_can( 'read' ) ) {
+                wp_die( __( 'You do not have sufficient permissions to access this page.', 'codboost-money-manager' ) );
+            }
+
+            $active_tab = isset( $_GET['tab'] ) ? sanitize_key( wp_unslash( $_GET['tab'] ) ) : 'dashboard';
+
+            echo '<div class="wrap codboost-money-manager">';
+            echo '<h1 class="cbm-page-title">' . esc_html__( 'Codboost Money Manager', 'codboost-money-manager' ) . '</h1>';
+
+            if ( isset( $_GET['cbm_msg'] ) ) {
+                $message = sanitize_text_field( wp_unslash( $_GET['cbm_msg'] ) );
+                $type    = isset( $_GET['cbm_typ'] ) ? sanitize_key( wp_unslash( $_GET['cbm_typ'] ) ) : 'success';
+                printf(
+                    '<div class="notice notice-%1$s is-dismissible"><p>%2$s</p></div>',
+                    'error' === $type ? 'error' : 'success',
+                    esc_html( $message )
+                );
+            }
+
+            $this->render_tabs( $active_tab );
+
+            switch ( $active_tab ) {
+                case 'transactions':
+                    $this->render_transactions_tab();
+                    break;
+                case 'accounts':
+                    $this->render_accounts_tab();
+                    break;
+                case 'reasons':
+                    $this->render_reasons_tab();
+                    break;
+                case 'dashboard':
+                default:
+                    $this->render_dashboard_tab();
+                    break;
+            }
+
+            echo '</div>';
+        }
+
+        /**
+         * Render tab navigation.
+         */
+        protected function render_tabs( string $active_tab ) : void {
+            $tabs = [
+                'dashboard'    => __( 'Analytics', 'codboost-money-manager' ),
+                'transactions' => __( 'Transactions', 'codboost-money-manager' ),
+                'accounts'     => __( 'Accounts', 'codboost-money-manager' ),
+                'reasons'      => __( 'Reasons', 'codboost-money-manager' ),
+            ];
+
+            echo '<nav class="cbm-tabs">';
+            foreach ( $tabs as $tab => $label ) {
+                $class = $active_tab === $tab ? 'cbm-tab is-active' : 'cbm-tab';
+                printf(
+                    '<a class="%1$s" href="%2$s">%3$s</a>',
+                    esc_attr( $class ),
+                    esc_url( add_query_arg( [ 'tab' => $tab ], menu_page_url( 'codboost-money-manager', false ) ) ),
+                    esc_html( $label )
+                );
+            }
+            echo '</nav>';
+        }
+
+        /**
+         * Render dashboard tab.
+         */
+        protected function render_dashboard_tab() : void {
+            $totals        = $this->get_totals();
+            $recent        = $this->get_transactions( 5 );
+            $accounts_data = $this->get_account_distribution();
+
+            echo '<section class="cbm-grid">';
+            $this->render_stat_card( __( 'Total Income', 'codboost-money-manager' ), $totals['income'], 'cbm-card--income' );
+            $this->render_stat_card( __( 'Total Outcome', 'codboost-money-manager' ), $totals['outcome'], 'cbm-card--outcome' );
+            $this->render_stat_card( __( 'Balance', 'codboost-money-manager' ), $totals['balance'], 'cbm-card--balance' );
+            echo '</section>';
+
+            echo '<section class="cbm-grid cbm-grid--two">';
+            echo '<div class="cbm-panel">';
+            echo '<h2>' . esc_html__( '12-Month Cashflow', 'codboost-money-manager' ) . '</h2>';
+            echo '<canvas id="cbm-cashflow-chart" height="220"></canvas>';
+            echo '</div>';
+
+            echo '<div class="cbm-panel">';
+            echo '<h2>' . esc_html__( 'Accounts Snapshot', 'codboost-money-manager' ) . '</h2>';
+            if ( empty( $accounts_data ) ) {
+                echo '<p>' . esc_html__( 'Add transactions to see distribution per account.', 'codboost-money-manager' ) . '</p>';
+            } else {
+                echo '<canvas id="cbm-accounts-chart" height="220"></canvas>';
+            }
+            echo '</div>';
+            echo '</section>';
+
+            echo '<section class="cbm-panel">';
+            echo '<h2>' . esc_html__( 'Recent Activity', 'codboost-money-manager' ) . '</h2>';
+            if ( empty( $recent ) ) {
+                echo '<p>' . esc_html__( 'No transactions recorded yet.', 'codboost-money-manager' ) . '</p>';
+            } else {
+                echo '<table class="cbm-table">';
+                echo '<thead><tr>';
+                echo '<th>' . esc_html__( 'Date', 'codboost-money-manager' ) . '</th>';
+                echo '<th>' . esc_html__( 'Type', 'codboost-money-manager' ) . '</th>';
+                echo '<th>' . esc_html__( 'Amount', 'codboost-money-manager' ) . '</th>';
+                echo '<th>' . esc_html__( 'Account', 'codboost-money-manager' ) . '</th>';
+                echo '<th>' . esc_html__( 'Reason', 'codboost-money-manager' ) . '</th>';
+                echo '</tr></thead><tbody>';
+                foreach ( $recent as $row ) {
+                    printf(
+                        '<tr><td>%1$s</td><td class="cbm-pill cbm-pill--%6$s">%2$s</td><td>%3$s</td><td>%4$s</td><td>%5$s</td></tr>',
+                        esc_html( date_i18n( get_option( 'date_format' ), strtotime( $row->transaction_date ) ) ),
+                        esc_html( ucfirst( $row->transaction_type ) ),
+                        esc_html( $this->format_currency( $row->amount ) ),
+                        esc_html( $row->account_name ?: __( 'Unassigned', 'codboost-money-manager' ) ),
+                        esc_html( $row->reason_name ?: __( 'Unassigned', 'codboost-money-manager' ) ),
+                        esc_attr( $row->transaction_type )
+                    );
+                }
+                echo '</tbody></table>';
+            }
+            echo '</section>';
+        }
+
+        /**
+         * Render transactions tab with form + table.
+         */
+        protected function render_transactions_tab() : void {
+            $accounts   = $this->get_accounts();
+            $reasons    = $this->get_reasons();
+            $rows       = $this->get_transactions( 20 );
+            $form_url   = admin_url( 'admin-post.php' );
+            $delete_url = admin_url( 'admin-post.php' );
+
+            echo '<section class="cbm-panel">';
+            echo '<h2>' . esc_html__( 'Log New Transaction', 'codboost-money-manager' ) . '</h2>';
+            echo '<form class="cbm-form" method="post" action="' . esc_url( $form_url ) . '">';
+            wp_nonce_field( self::NONCE_ACTION, '_cbm_nonce' );
+            echo '<input type="hidden" name="action" value="cmm_save_transaction">';
+            echo '<div class="cbm-form__grid">';
+            echo $this->render_select_field( 'transaction_type', __( 'Type', 'codboost-money-manager' ), [
+                'income'  => __( 'Income', 'codboost-money-manager' ),
+                'outcome' => __( 'Outcome', 'codboost-money-manager' ),
+            ] );
+            echo $this->render_input_field( 'amount', __( 'Amount', 'codboost-money-manager' ), 'number', [ 'step' => '0.01', 'min' => '0' ] );
+            echo $this->render_select_field( 'account_id', __( 'Account', 'codboost-money-manager' ), $this->convert_records_to_options( $accounts ) );
+            echo $this->render_select_field( 'reason_id', __( 'Reason', 'codboost-money-manager' ), $this->convert_records_to_options( $reasons ) );
+            echo $this->render_input_field( 'transaction_date', __( 'Date', 'codboost-money-manager' ), 'date', [ 'value' => wp_date( 'Y-m-d' ) ] );
+            echo '</div>';
+            echo $this->render_textarea_field( 'note', __( 'Notes (optional)', 'codboost-money-manager' ) );
+            echo '<button type="submit" class="button button-primary">' . esc_html__( 'Save Transaction', 'codboost-money-manager' ) . '</button>';
+            echo '</form>';
+            echo '</section>';
+
+            echo '<section class="cbm-panel">';
+            echo '<h2>' . esc_html__( 'Latest Transactions', 'codboost-money-manager' ) . '</h2>';
+            if ( empty( $rows ) ) {
+                echo '<p>' . esc_html__( 'No transactions yet. Add your first entry above.', 'codboost-money-manager' ) . '</p>';
+            } else {
+                echo '<table class="cbm-table">';
+                echo '<thead><tr>';
+                echo '<th>' . esc_html__( 'Date', 'codboost-money-manager' ) . '</th>';
+                echo '<th>' . esc_html__( 'Type', 'codboost-money-manager' ) . '</th>';
+                echo '<th>' . esc_html__( 'Amount', 'codboost-money-manager' ) . '</th>';
+                echo '<th>' . esc_html__( 'Account', 'codboost-money-manager' ) . '</th>';
+                echo '<th>' . esc_html__( 'Reason', 'codboost-money-manager' ) . '</th>';
+                echo '<th>' . esc_html__( 'Notes', 'codboost-money-manager' ) . '</th>';
+                echo '<th>' . esc_html__( 'Actions', 'codboost-money-manager' ) . '</th>';
+                echo '</tr></thead><tbody>';
+                foreach ( $rows as $row ) {
+                    echo '<tr>';
+                    echo '<td>' . esc_html( date_i18n( get_option( 'date_format' ), strtotime( $row->transaction_date ) ) ) . '</td>';
+                    echo '<td><span class="cbm-pill cbm-pill--' . esc_attr( $row->transaction_type ) . '">' . esc_html( ucfirst( $row->transaction_type ) ) . '</span></td>';
+                    echo '<td>' . esc_html( $this->format_currency( $row->amount ) ) . '</td>';
+                    echo '<td>' . esc_html( $row->account_name ?: __( 'Unassigned', 'codboost-money-manager' ) ) . '</td>';
+                    echo '<td>' . esc_html( $row->reason_name ?: __( 'Unassigned', 'codboost-money-manager' ) ) . '</td>';
+                    echo '<td>' . esc_html( $row->note ) . '</td>';
+                    echo '<td>';
+                    printf(
+                        '<form method="post" action="%1$s" onsubmit="return confirm(\'%2$s\');">',
+                        esc_url( $delete_url ),
+                        esc_js( __( 'Are you sure you want to delete this transaction?', 'codboost-money-manager' ) )
+                    );
+                    wp_nonce_field( self::NONCE_ACTION, '_cbm_nonce' );
+                    echo '<input type="hidden" name="action" value="cmm_delete_transaction">';
+                    echo '<input type="hidden" name="transaction_id" value="' . esc_attr( $row->id ) . '">';
+                    echo '<button type="submit" class="button button-link-delete">' . esc_html__( 'Delete', 'codboost-money-manager' ) . '</button>';
+                    echo '</form>';
+                    echo '</td>';
+                    echo '</tr>';
+                }
+                echo '</tbody></table>';
+            }
+            echo '</section>';
+        }
+
+        /**
+         * Render accounts tab.
+         */
+        protected function render_accounts_tab() : void {
+            $accounts = $this->get_accounts();
+            $form_url = admin_url( 'admin-post.php' );
+
+            echo '<section class="cbm-panel">';
+            echo '<h2>' . esc_html__( 'Manage Accounts', 'codboost-money-manager' ) . '</h2>';
+            echo '<form class="cbm-form" method="post" action="' . esc_url( $form_url ) . '">';
+            wp_nonce_field( self::NONCE_ACTION, '_cbm_nonce' );
+            echo '<input type="hidden" name="action" value="cmm_save_account">';
+            echo $this->render_input_field( 'name', __( 'Account Name', 'codboost-money-manager' ) );
+            echo $this->render_textarea_field( 'description', __( 'Description (optional)', 'codboost-money-manager' ) );
+            echo '<button type="submit" class="button button-primary">' . esc_html__( 'Add Account', 'codboost-money-manager' ) . '</button>';
+            echo '</form>';
+            echo '</section>';
+
+            echo '<section class="cbm-panel">';
+            echo '<h2>' . esc_html__( 'Saved Accounts', 'codboost-money-manager' ) . '</h2>';
+            if ( empty( $accounts ) ) {
+                echo '<p>' . esc_html__( 'No accounts created yet.', 'codboost-money-manager' ) . '</p>';
+            } else {
+                echo '<ul class="cbm-list">';
+                foreach ( $accounts as $account ) {
+                    echo '<li>';
+                    echo '<span class="cbm-list__title">' . esc_html( $account->name ) . '</span>';
+                    if ( ! empty( $account->description ) ) {
+                        echo '<span class="cbm-list__meta">' . esc_html( $account->description ) . '</span>';
+                    }
+                    printf(
+                        '<form method="post" action="%1$s" onsubmit="return confirm(\'%2$s\');">',
+                        esc_url( $form_url ),
+                        esc_js( __( 'Delete this account? Existing transactions will keep the previous reference.', 'codboost-money-manager' ) )
+                    );
+                    wp_nonce_field( self::NONCE_ACTION, '_cbm_nonce' );
+                    echo '<input type="hidden" name="action" value="cmm_delete_account">';
+                    echo '<input type="hidden" name="account_id" value="' . esc_attr( $account->id ) . '">';
+                    echo '<button type="submit" class="button button-link-delete">' . esc_html__( 'Delete', 'codboost-money-manager' ) . '</button>';
+                    echo '</form>';
+                    echo '</li>';
+                }
+                echo '</ul>';
+            }
+            echo '</section>';
+        }
+
+        /**
+         * Render reasons tab.
+         */
+        protected function render_reasons_tab() : void {
+            $reasons  = $this->get_reasons();
+            $form_url = admin_url( 'admin-post.php' );
+
+            echo '<section class="cbm-panel">';
+            echo '<h2>' . esc_html__( 'Manage Reasons', 'codboost-money-manager' ) . '</h2>';
+            echo '<form class="cbm-form" method="post" action="' . esc_url( $form_url ) . '">';
+            wp_nonce_field( self::NONCE_ACTION, '_cbm_nonce' );
+            echo '<input type="hidden" name="action" value="cmm_save_reason">';
+            echo '<div class="cbm-form__grid">';
+            echo $this->render_input_field( 'name', __( 'Reason Name', 'codboost-money-manager' ) );
+            echo $this->render_select_field( 'type', __( 'Default Type', 'codboost-money-manager' ), [
+                'income'  => __( 'Income', 'codboost-money-manager' ),
+                'outcome' => __( 'Outcome', 'codboost-money-manager' ),
+                'general' => __( 'General', 'codboost-money-manager' ),
+            ], 'general' );
+            echo '</div>';
+            echo $this->render_textarea_field( 'description', __( 'Description (optional)', 'codboost-money-manager' ) );
+            echo '<button type="submit" class="button button-primary">' . esc_html__( 'Add Reason', 'codboost-money-manager' ) . '</button>';
+            echo '</form>';
+            echo '</section>';
+
+            echo '<section class="cbm-panel">';
+            echo '<h2>' . esc_html__( 'Saved Reasons', 'codboost-money-manager' ) . '</h2>';
+            if ( empty( $reasons ) ) {
+                echo '<p>' . esc_html__( 'No reasons created yet.', 'codboost-money-manager' ) . '</p>';
+            } else {
+                echo '<ul class="cbm-list">';
+                foreach ( $reasons as $reason ) {
+                    echo '<li>';
+                    echo '<span class="cbm-list__title">' . esc_html( $reason->name ) . '</span>';
+                    echo '<span class="cbm-list__badge">' . esc_html( ucfirst( $reason->type ) ) . '</span>';
+                    if ( ! empty( $reason->description ) ) {
+                        echo '<span class="cbm-list__meta">' . esc_html( $reason->description ) . '</span>';
+                    }
+                    printf(
+                        '<form method="post" action="%1$s" onsubmit="return confirm(\'%2$s\');">',
+                        esc_url( $form_url ),
+                        esc_js( __( 'Delete this reason?', 'codboost-money-manager' ) )
+                    );
+                    wp_nonce_field( self::NONCE_ACTION, '_cbm_nonce' );
+                    echo '<input type="hidden" name="action" value="cmm_delete_reason">';
+                    echo '<input type="hidden" name="reason_id" value="' . esc_attr( $reason->id ) . '">';
+                    echo '<button type="submit" class="button button-link-delete">' . esc_html__( 'Delete', 'codboost-money-manager' ) . '</button>';
+                    echo '</form>';
+                    echo '</li>';
+                }
+                echo '</ul>';
+            }
+            echo '</section>';
+        }
+
+        /**
+         * Handle account creation.
+         */
+        public function handle_save_account() : void {
+            $this->verify_permissions();
+
+            $name        = isset( $_POST['name'] ) ? sanitize_text_field( wp_unslash( $_POST['name'] ) ) : '';
+            $description = isset( $_POST['description'] ) ? sanitize_textarea_field( wp_unslash( $_POST['description'] ) ) : '';
+
+            if ( empty( $name ) ) {
+                $this->redirect_with_message( __( 'Account name is required.', 'codboost-money-manager' ), 'error', 'accounts' );
+            }
+
+            global $wpdb;
+            $accounts_table = $wpdb->prefix . 'cbm_accounts';
+
+            $wpdb->insert( $accounts_table, [
+                'name'        => $name,
+                'description' => $description,
+            ] );
+
+            $this->redirect_with_message( __( 'Account created successfully.', 'codboost-money-manager' ), 'success', 'accounts' );
+        }
+
+        /**
+         * Handle account deletion.
+         */
+        public function handle_delete_account() : void {
+            $this->verify_permissions();
+
+            $account_id = isset( $_POST['account_id'] ) ? absint( $_POST['account_id'] ) : 0;
+            if ( ! $account_id ) {
+                $this->redirect_with_message( __( 'Invalid account.', 'codboost-money-manager' ), 'error', 'accounts' );
+            }
+
+            global $wpdb;
+            $accounts_table = $wpdb->prefix . 'cbm_accounts';
+            $wpdb->delete( $accounts_table, [ 'id' => $account_id ], [ '%d' ] );
+
+            $this->redirect_with_message( __( 'Account deleted.', 'codboost-money-manager' ), 'success', 'accounts' );
+        }
+
+        /**
+         * Handle reason creation.
+         */
+        public function handle_save_reason() : void {
+            $this->verify_permissions();
+
+            $name        = isset( $_POST['name'] ) ? sanitize_text_field( wp_unslash( $_POST['name'] ) ) : '';
+            $type        = isset( $_POST['type'] ) ? sanitize_key( wp_unslash( $_POST['type'] ) ) : 'general';
+            $description = isset( $_POST['description'] ) ? sanitize_textarea_field( wp_unslash( $_POST['description'] ) ) : '';
+
+            if ( empty( $name ) ) {
+                $this->redirect_with_message( __( 'Reason name is required.', 'codboost-money-manager' ), 'error', 'reasons' );
+            }
+
+            global $wpdb;
+            $reasons_table = $wpdb->prefix . 'cbm_reasons';
+
+            $wpdb->insert( $reasons_table, [
+                'name'        => $name,
+                'type'        => in_array( $type, [ 'income', 'outcome', 'general' ], true ) ? $type : 'general',
+                'description' => $description,
+            ] );
+
+            $this->redirect_with_message( __( 'Reason created successfully.', 'codboost-money-manager' ), 'success', 'reasons' );
+        }
+
+        /**
+         * Handle reason deletion.
+         */
+        public function handle_delete_reason() : void {
+            $this->verify_permissions();
+
+            $reason_id = isset( $_POST['reason_id'] ) ? absint( $_POST['reason_id'] ) : 0;
+            if ( ! $reason_id ) {
+                $this->redirect_with_message( __( 'Invalid reason.', 'codboost-money-manager' ), 'error', 'reasons' );
+            }
+
+            global $wpdb;
+            $reasons_table = $wpdb->prefix . 'cbm_reasons';
+            $wpdb->delete( $reasons_table, [ 'id' => $reason_id ], [ '%d' ] );
+
+            $this->redirect_with_message( __( 'Reason deleted.', 'codboost-money-manager' ), 'success', 'reasons' );
+        }
+
+        /**
+         * Handle transaction creation.
+         */
+        public function handle_save_transaction() : void {
+            $this->verify_permissions();
+
+            $type             = isset( $_POST['transaction_type'] ) ? sanitize_key( wp_unslash( $_POST['transaction_type'] ) ) : 'income';
+            $amount           = isset( $_POST['amount'] ) ? floatval( wp_unslash( $_POST['amount'] ) ) : 0;
+            $account_id       = isset( $_POST['account_id'] ) ? absint( $_POST['account_id'] ) : 0;
+            $reason_id        = isset( $_POST['reason_id'] ) ? absint( $_POST['reason_id'] ) : 0;
+            $transaction_date = isset( $_POST['transaction_date'] ) ? sanitize_text_field( wp_unslash( $_POST['transaction_date'] ) ) : '';
+            $note             = isset( $_POST['note'] ) ? sanitize_textarea_field( wp_unslash( $_POST['note'] ) ) : '';
+
+            if ( $amount <= 0 ) {
+                $this->redirect_with_message( __( 'Amount must be greater than zero.', 'codboost-money-manager' ), 'error', 'transactions' );
+            }
+
+            if ( ! in_array( $type, [ 'income', 'outcome' ], true ) ) {
+                $type = 'income';
+            }
+
+            $timestamp = $transaction_date ? strtotime( $transaction_date ) : false;
+            if ( false === $timestamp ) {
+                $transaction_date = wp_date( 'Y-m-d' );
+            } else {
+                $transaction_date = wp_date( 'Y-m-d', $timestamp );
+            }
+
+            global $wpdb;
+            $transactions_table = $wpdb->prefix . 'cbm_transactions';
+
+            $wpdb->insert( $transactions_table, [
+                'user_id'          => get_current_user_id(),
+                'transaction_type' => $type,
+                'amount'           => $amount,
+                'account_id'       => $account_id ?: null,
+                'reason_id'        => $reason_id ?: null,
+                'note'             => $note,
+                'transaction_date' => $transaction_date,
+            ], [
+                '%d',
+                '%s',
+                '%f',
+                '%d',
+                '%d',
+                '%s',
+                '%s',
+            ] );
+
+            $this->redirect_with_message( __( 'Transaction saved successfully.', 'codboost-money-manager' ), 'success', 'transactions' );
+        }
+
+        /**
+         * Handle transaction deletion.
+         */
+        public function handle_delete_transaction() : void {
+            $this->verify_permissions();
+
+            $transaction_id = isset( $_POST['transaction_id'] ) ? absint( $_POST['transaction_id'] ) : 0;
+            if ( ! $transaction_id ) {
+                $this->redirect_with_message( __( 'Invalid transaction.', 'codboost-money-manager' ), 'error', 'transactions' );
+            }
+
+            global $wpdb;
+            $transactions_table = $wpdb->prefix . 'cbm_transactions';
+            $wpdb->delete( $transactions_table, [ 'id' => $transaction_id ], [ '%d' ] );
+
+            $this->redirect_with_message( __( 'Transaction deleted.', 'codboost-money-manager' ), 'success', 'transactions' );
+        }
+
+        /**
+         * Verify nonce and permissions.
+         */
+        protected function verify_permissions() : void {
+            if ( ! is_user_logged_in() ) {
+                wp_die( __( 'You must be logged in.', 'codboost-money-manager' ) );
+            }
+
+            if ( ! isset( $_POST['_cbm_nonce'] ) || ! wp_verify_nonce( sanitize_text_field( wp_unslash( $_POST['_cbm_nonce'] ) ), self::NONCE_ACTION ) ) {
+                wp_die( __( 'Security check failed.', 'codboost-money-manager' ) );
+            }
+        }
+
+        /**
+         * Redirect helper.
+         */
+        protected function redirect_with_message( string $message, string $type = 'success', string $tab = 'dashboard' ) : void {
+            $referer = isset( $_POST['_wp_http_referer'] ) ? esc_url_raw( wp_unslash( $_POST['_wp_http_referer'] ) ) : '';
+
+            if ( $referer && false === strpos( $referer, 'wp-admin' ) ) {
+                $url = add_query_arg(
+                    [
+                        'cbm_msg' => rawurlencode( $message ),
+                        'cbm_typ' => $type,
+                    ],
+                    $referer
+                );
+            } else {
+                $url = add_query_arg(
+                    [
+                        'page'    => 'codboost-money-manager',
+                        'tab'     => $tab,
+                        'cbm_msg' => rawurlencode( $message ),
+                        'cbm_typ' => $type,
+                    ],
+                    admin_url( 'admin.php' )
+                );
+            }
+
+            wp_safe_redirect( $url );
+            exit;
+        }
+
+        /**
+         * Get totals summary.
+         */
+        protected function get_totals() : array {
+            global $wpdb;
+            $table = $wpdb->prefix . 'cbm_transactions';
+
+            $results = $wpdb->get_results( "SELECT transaction_type, SUM(amount) AS total FROM {$table} GROUP BY transaction_type" );
+            $totals  = [ 'income' => 0.0, 'outcome' => 0.0 ];
+
+            foreach ( $results as $row ) {
+                $totals[ $row->transaction_type ] = (float) $row->total;
+            }
+
+            $totals['balance'] = $totals['income'] - $totals['outcome'];
+
+            return $totals;
+        }
+
+        /**
+         * Fetch recent transactions.
+         */
+        protected function get_transactions( int $limit = 20 ) : array {
+            global $wpdb;
+            $transactions_table = $wpdb->prefix . 'cbm_transactions';
+            $accounts_table     = $wpdb->prefix . 'cbm_accounts';
+            $reasons_table      = $wpdb->prefix . 'cbm_reasons';
+
+            $query = $wpdb->prepare(
+                "SELECT t.*, a.name AS account_name, r.name AS reason_name
+                FROM {$transactions_table} t
+                LEFT JOIN {$accounts_table} a ON a.id = t.account_id
+                LEFT JOIN {$reasons_table} r ON r.id = t.reason_id
+                ORDER BY t.transaction_date DESC, t.created_at DESC
+                LIMIT %d",
+                $limit
+            );
+
+            return $wpdb->get_results( $query ) ?: [];
+        }
+
+        /**
+         * Fetch accounts.
+         */
+        protected function get_accounts() : array {
+            global $wpdb;
+            $table = $wpdb->prefix . 'cbm_accounts';
+
+            return $wpdb->get_results( "SELECT * FROM {$table} ORDER BY name ASC" ) ?: [];
+        }
+
+        /**
+         * Fetch reasons.
+         */
+        protected function get_reasons() : array {
+            global $wpdb;
+            $table = $wpdb->prefix . 'cbm_reasons';
+
+            return $wpdb->get_results( "SELECT * FROM {$table} ORDER BY name ASC" ) ?: [];
+        }
+
+        /**
+         * Build chart data for JS.
+         */
+        protected function get_chart_data() : array {
+            global $wpdb;
+            $transactions_table = $wpdb->prefix . 'cbm_transactions';
+            $accounts_table     = $wpdb->prefix . 'cbm_accounts';
+
+            $labels      = [];
+            $income_data = [];
+            $out_data    = [];
+
+            for ( $i = 11; $i >= 0; $i -- ) {
+                $month_key = gmdate( 'Y-m', strtotime( '-' . $i . ' months' ) );
+                $labels[]  = date_i18n( 'M Y', strtotime( $month_key . '-01' ) );
+
+                $prepared = $wpdb->prepare(
+                    "SELECT transaction_type, SUM(amount) as total
+                    FROM {$transactions_table}
+                    WHERE DATE_FORMAT(transaction_date, '%%Y-%%m') = %s
+                    GROUP BY transaction_type",
+                    $month_key
+                );
+
+                $results = $wpdb->get_results( $prepared );
+                $income  = 0.0;
+                $outcome = 0.0;
+                foreach ( $results as $row ) {
+                    if ( 'income' === $row->transaction_type ) {
+                        $income = (float) $row->total;
+                    }
+                    if ( 'outcome' === $row->transaction_type ) {
+                        $outcome = (float) $row->total;
+                    }
+                }
+                $income_data[] = $income;
+                $out_data[]    = $outcome;
+            }
+
+            $accounts_distribution = $wpdb->get_results(
+                "SELECT a.name AS account, SUM(CASE WHEN t.transaction_type = 'income' THEN t.amount ELSE -t.amount END) AS balance
+                FROM {$transactions_table} t
+                LEFT JOIN {$accounts_table} a ON a.id = t.account_id
+                GROUP BY a.name"
+            );
+
+            return [
+                'labels'               => $labels,
+                'income'               => $income_data,
+                'outcome'              => $out_data,
+                'accountsDistribution' => $accounts_distribution,
+            ];
+        }
+
+        /**
+         * Account distribution for server rendering fallback.
+         */
+        protected function get_account_distribution() : array {
+            $data = $this->get_chart_data()['accountsDistribution'];
+
+            if ( empty( $data ) ) {
+                return [];
+            }
+
+            $distribution = [];
+            foreach ( $data as $row ) {
+                if ( null === $row->account ) {
+                    $row->account = __( 'Unassigned', 'codboost-money-manager' );
+                }
+                $distribution[] = [
+                    'account' => $row->account,
+                    'balance' => (float) $row->balance,
+                ];
+            }
+
+            return $distribution;
+        }
+
+        /**
+         * Render stat card helper.
+         */
+        protected function render_stat_card( string $title, float $value, string $class = '' ) : void {
+            printf(
+                '<article class="cbm-card %3$s"><h3>%1$s</h3><p>%2$s</p></article>',
+                esc_html( $title ),
+                esc_html( $this->format_currency( $value ) ),
+                esc_attr( $class )
+            );
+        }
+
+        /**
+         * Render input helper.
+         */
+        protected function render_input_field( string $name, string $label, string $type = 'text', array $attrs = [], bool $required = true ) : string {
+            $value      = '';
+            $attributes = '';
+
+            if ( isset( $attrs['value'] ) ) {
+                $value = $attrs['value'];
+                unset( $attrs['value'] );
+            }
+
+            foreach ( $attrs as $attr => $attr_value ) {
+                $attributes .= sprintf( ' %s="%s"', esc_attr( $attr ), esc_attr( $attr_value ) );
+            }
+
+            return sprintf(
+                '<label class="cbm-field"><span>%1$s</span><input type="%3$s" name="%2$s" id="%2$s" value="%5$s" %4$s %6$s></label>',
+                esc_html( $label ),
+                esc_attr( $name ),
+                esc_attr( $type ),
+                $attributes,
+                esc_attr( $value ),
+                $required ? 'required' : ''
+            );
+        }
+
+        /**
+         * Render textarea helper.
+         */
+        protected function render_textarea_field( string $name, string $label ) : string {
+            return sprintf(
+                '<label class="cbm-field"><span>%1$s</span><textarea name="%2$s" id="%2$s" rows="3"></textarea></label>',
+                esc_html( $label ),
+                esc_attr( $name )
+            );
+        }
+
+        /**
+         * Render select helper.
+         */
+        protected function render_select_field( string $name, string $label, array $options, string $default = '' ) : string {
+            $html = '<label class="cbm-field"><span>' . esc_html( $label ) . '</span><select name="' . esc_attr( $name ) . '" id="' . esc_attr( $name ) . '">';
+
+            $html .= '<option value="">' . esc_html__( 'Select option', 'codboost-money-manager' ) . '</option>';
+
+            foreach ( $options as $value => $text ) {
+                $selected = selected( (string) $default, (string) $value, false );
+                $html    .= '<option value="' . esc_attr( $value ) . '" ' . $selected . '>' . esc_html( $text ) . '</option>';
+            }
+
+            $html .= '</select></label>';
+
+            return $html;
+        }
+
+        /**
+         * Convert DB rows to options array.
+         */
+        protected function convert_records_to_options( array $records ) : array {
+            $options = [];
+            foreach ( $records as $record ) {
+                $options[ $record->id ] = $record->name;
+            }
+
+            return $options;
+        }
+
+        /**
+         * Format currency helper.
+         */
+        protected function format_currency( float $value ) : string {
+            $symbol = get_option( 'woocommerce_currency_symbol' );
+            if ( empty( $symbol ) ) {
+                $symbol = 'DZD';
+            }
+
+            $symbol = apply_filters( 'codboost_money_manager_currency_symbol', $symbol, $value );
+
+            return sprintf( '%s %s', $symbol, number_format_i18n( $value, 2 ) );
+        }
+
+        /**
+         * Shortcode renderer for frontend dashboard.
+         */
+        public function render_shortcode() : string {
+            if ( ! is_user_logged_in() ) {
+                $login_url = wp_login_url( get_permalink() );
+                return '<div class="cbm-notice">' . sprintf(
+                    /* translators: %s is the login URL */
+                    esc_html__( 'You need to be logged in to access the Codboost Money Manager. %s', 'codboost-money-manager' ),
+                    '<a href="' . esc_url( $login_url ) . '" class="cbm-link">' . esc_html__( 'Login now', 'codboost-money-manager' ) . '</a>'
+                ) . '</div>';
+            }
+
+            ob_start();
+            echo '<div class="codboost-money-manager">';
+            if ( isset( $_GET['cbm_msg'] ) ) {
+                $message = sanitize_text_field( wp_unslash( $_GET['cbm_msg'] ) );
+                $type    = isset( $_GET['cbm_typ'] ) ? sanitize_key( wp_unslash( $_GET['cbm_typ'] ) ) : 'success';
+                printf(
+                    '<div class="cbm-panel %1$s"><p>%2$s</p></div>',
+                    'error' === $type ? 'cbm-panel--error' : 'cbm-panel--success',
+                    esc_html( $message )
+                );
+            }
+            $this->render_dashboard_tab();
+            $this->render_transactions_tab();
+            echo '</div>';
+
+            return ob_get_clean();
+        }
+    }
+}
+
+Codboost_Money_Manager::instance();

--- a/codboost-plugin.php
+++ b/codboost-plugin.php
@@ -18,8 +18,9 @@ if ( ! defined( 'ABSPATH' ) ) {
 if ( ! class_exists( 'Codboost_Money_Manager' ) ) {
 
     class Codboost_Money_Manager {
-        const VERSION = '1.0.0';
+        const VERSION = '1.1.0';
         const NONCE_ACTION = 'codboost_money_manager_action';
+        const DEMO_OPTION = 'codboost_money_manager_demo_seeded';
 
         /**
          * Singleton instance.
@@ -45,10 +46,12 @@ if ( ! class_exists( 'Codboost_Money_Manager' ) ) {
         private function __construct() {
             register_activation_hook( __FILE__, [ $this, 'activate' ] );
 
+            add_action( 'plugins_loaded', [ $this, 'load_textdomain' ] );
+            add_action( 'init', [ $this, 'maybe_upgrade_schema' ] );
+
             add_action( 'admin_menu', [ $this, 'register_admin_menu' ] );
             add_action( 'admin_enqueue_scripts', [ $this, 'enqueue_admin_assets' ] );
             add_action( 'wp_enqueue_scripts', [ $this, 'enqueue_front_assets' ] );
-            add_action( 'plugins_loaded', [ $this, 'load_textdomain' ] );
 
             add_action( 'admin_post_cmm_save_account', [ $this, 'handle_save_account' ] );
             add_action( 'admin_post_cmm_delete_account', [ $this, 'handle_delete_account' ] );
@@ -58,6 +61,8 @@ if ( ! class_exists( 'Codboost_Money_Manager' ) ) {
 
             add_action( 'admin_post_cmm_save_transaction', [ $this, 'handle_save_transaction' ] );
             add_action( 'admin_post_cmm_delete_transaction', [ $this, 'handle_delete_transaction' ] );
+
+            add_action( 'admin_post_cmm_import_demo', [ $this, 'handle_import_demo' ] );
 
             add_shortcode( 'codboost_money_manager', [ $this, 'render_shortcode' ] );
         }
@@ -83,6 +88,12 @@ if ( ! class_exists( 'Codboost_Money_Manager' ) ) {
                 reason_id BIGINT UNSIGNED NULL,
                 account_id BIGINT UNSIGNED NULL,
                 note TEXT NULL,
+                party VARCHAR(191) NULL,
+                reference VARCHAR(191) NULL,
+                tags TEXT NULL,
+                currency VARCHAR(10) NOT NULL DEFAULT 'DZD',
+                status VARCHAR(40) NOT NULL DEFAULT 'cleared',
+                exchange_rate DECIMAL(14,4) NOT NULL DEFAULT 1,
                 transaction_date DATE NOT NULL,
                 created_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
                 PRIMARY KEY  (id),
@@ -115,14 +126,92 @@ if ( ! class_exists( 'Codboost_Money_Manager' ) ) {
             dbDelta( $reasons_sql );
             dbDelta( $transactions_sql );
 
-            $default_accounts = [ 'Cash Wallet', 'Baridi Mob' ];
+            $this->seed_default_terms();
+        }
+
+        /**
+         * Ensure schema stays up to date when new versions introduce columns.
+         */
+        public function maybe_upgrade_schema() : void {
+            global $wpdb;
+
+            $transactions_table = $wpdb->prefix . 'cbm_transactions';
+
+            $columns = [
+                'party'         => "ALTER TABLE {$transactions_table} ADD COLUMN party VARCHAR(191) NULL AFTER note",
+                'reference'     => "ALTER TABLE {$transactions_table} ADD COLUMN reference VARCHAR(191) NULL AFTER party",
+                'tags'          => "ALTER TABLE {$transactions_table} ADD COLUMN tags TEXT NULL AFTER reference",
+                'currency'      => "ALTER TABLE {$transactions_table} ADD COLUMN currency VARCHAR(10) NOT NULL DEFAULT 'DZD' AFTER tags",
+                'status'        => "ALTER TABLE {$transactions_table} ADD COLUMN status VARCHAR(40) NOT NULL DEFAULT 'cleared' AFTER currency",
+                'exchange_rate' => "ALTER TABLE {$transactions_table} ADD COLUMN exchange_rate DECIMAL(14,4) NOT NULL DEFAULT 1 AFTER status",
+            ];
+
+            foreach ( $columns as $column => $sql ) {
+                $has_column = $wpdb->get_results( $wpdb->prepare( "SHOW COLUMNS FROM {$transactions_table} LIKE %s", $column ) );
+                if ( empty( $has_column ) ) {
+                    $wpdb->query( $sql );
+                }
+            }
+        }
+
+        /**
+         * Seed core accounts and reasons when activating or importing demo data.
+         */
+        protected function seed_default_terms() : void {
+            global $wpdb;
+
+            $accounts_table = $wpdb->prefix . 'cbm_accounts';
+            $reasons_table  = $wpdb->prefix . 'cbm_reasons';
+
+            $default_accounts = [
+                [
+                    'name'        => __( 'Cash Wallet', 'codboost-money-manager' ),
+                    'description' => __( 'Physical cash on hand for Codboost operations.', 'codboost-money-manager' ),
+                ],
+                [
+                    'name'        => __( 'Baridi Mob', 'codboost-money-manager' ),
+                    'description' => __( 'Primary mobile payment account.', 'codboost-money-manager' ),
+                ],
+                [
+                    'name'        => __( 'Bank - BNP Paribas', 'codboost-money-manager' ),
+                    'description' => __( 'Corporate current account for settlements and payroll.', 'codboost-money-manager' ),
+                ],
+            ];
+
             foreach ( $default_accounts as $account ) {
-                $existing = $wpdb->get_var( $wpdb->prepare( "SELECT id FROM {$accounts_table} WHERE name = %s", $account ) );
+                $existing = $wpdb->get_var( $wpdb->prepare( "SELECT id FROM {$accounts_table} WHERE name = %s", $account['name'] ) );
                 if ( ! $existing ) {
-                    $wpdb->insert( $accounts_table, [
-                        'name'        => $account,
-                        'description' => sprintf( __( '%s account added by default during plugin activation.', 'codboost-money-manager' ), $account ),
-                    ] );
+                    $wpdb->insert( $accounts_table, $account );
+                }
+            }
+
+            $default_reasons = [
+                [
+                    'name'        => __( 'Product Revenue', 'codboost-money-manager' ),
+                    'type'        => 'income',
+                    'description' => __( 'Income generated from Codboost product sales and subscriptions.', 'codboost-money-manager' ),
+                ],
+                [
+                    'name'        => __( 'Client Services', 'codboost-money-manager' ),
+                    'type'        => 'income',
+                    'description' => __( 'Consulting and services invoiced to Codboost partners.', 'codboost-money-manager' ),
+                ],
+                [
+                    'name'        => __( 'Team Salaries', 'codboost-money-manager' ),
+                    'type'        => 'outcome',
+                    'description' => __( 'Monthly payroll and benefits.', 'codboost-money-manager' ),
+                ],
+                [
+                    'name'        => __( 'Platform Expenses', 'codboost-money-manager' ),
+                    'type'        => 'outcome',
+                    'description' => __( 'Hosting, marketing, and tooling costs.', 'codboost-money-manager' ),
+                ],
+            ];
+
+            foreach ( $default_reasons as $reason ) {
+                $existing = $wpdb->get_var( $wpdb->prepare( "SELECT id FROM {$reasons_table} WHERE name = %s", $reason['name'] ) );
+                if ( ! $existing ) {
+                    $wpdb->insert( $reasons_table, $reason );
                 }
             }
         }
@@ -245,6 +334,9 @@ if ( ! class_exists( 'Codboost_Money_Manager' ) ) {
                 case 'reasons':
                     $this->render_reasons_tab();
                     break;
+                case 'setup':
+                    $this->render_setup_tab();
+                    break;
                 case 'dashboard':
                 default:
                     $this->render_dashboard_tab();
@@ -263,6 +355,7 @@ if ( ! class_exists( 'Codboost_Money_Manager' ) ) {
                 'transactions' => __( 'Transactions', 'codboost-money-manager' ),
                 'accounts'     => __( 'Accounts', 'codboost-money-manager' ),
                 'reasons'      => __( 'Reasons', 'codboost-money-manager' ),
+                'setup'        => __( 'Setup & Import', 'codboost-money-manager' ),
             ];
 
             echo '<nav class="cbm-tabs">';
@@ -282,38 +375,72 @@ if ( ! class_exists( 'Codboost_Money_Manager' ) ) {
          * Render dashboard tab.
          */
         protected function render_dashboard_tab() : void {
-            $totals        = $this->get_totals();
-            $recent        = $this->get_transactions( 5 );
-            $accounts_data = $this->get_account_distribution();
+            $totals          = $this->get_totals();
+            $recent          = $this->get_transactions( 5 );
+            $accounts_data   = $this->get_account_distribution();
+            $chart_data      = $this->get_chart_data();
+            $reason_data     = $chart_data['reasonBreakdown'] ?? [];
+            $insights        = $chart_data['insights'] ?? [];
 
-            echo '<section class="cbm-grid">';
+            echo '<section class="cbm-grid cbm-grid--stats">';
             $this->render_stat_card( __( 'Total Income', 'codboost-money-manager' ), $totals['income'], 'cbm-card--income' );
             $this->render_stat_card( __( 'Total Outcome', 'codboost-money-manager' ), $totals['outcome'], 'cbm-card--outcome' );
             $this->render_stat_card( __( 'Balance', 'codboost-money-manager' ), $totals['balance'], 'cbm-card--balance' );
+            $this->render_stat_card( __( 'Average Monthly Net', 'codboost-money-manager' ), $totals['average_net'], 'cbm-card--trend' );
             echo '</section>';
 
             echo '<section class="cbm-grid cbm-grid--two">';
-            echo '<div class="cbm-panel">';
+            echo '<div class="cbm-panel cbm-panel--elevated">';
             echo '<h2>' . esc_html__( '12-Month Cashflow', 'codboost-money-manager' ) . '</h2>';
-            echo '<canvas id="cbm-cashflow-chart" height="220"></canvas>';
+            echo '<canvas id="cbm-cashflow-chart" height="240"></canvas>';
             echo '</div>';
 
-            echo '<div class="cbm-panel">';
+            echo '<div class="cbm-panel cbm-panel--elevated">';
+            echo '<h2>' . esc_html__( 'Cumulative Balance', 'codboost-money-manager' ) . '</h2>';
+            echo '<canvas id="cbm-balance-chart" height="240"></canvas>';
+            echo '</div>';
+            echo '</section>';
+
+            echo '<section class="cbm-grid cbm-grid--two">';
+            echo '<div class="cbm-panel cbm-panel--elevated">';
             echo '<h2>' . esc_html__( 'Accounts Snapshot', 'codboost-money-manager' ) . '</h2>';
             if ( empty( $accounts_data ) ) {
                 echo '<p>' . esc_html__( 'Add transactions to see distribution per account.', 'codboost-money-manager' ) . '</p>';
             } else {
-                echo '<canvas id="cbm-accounts-chart" height="220"></canvas>';
+                echo '<canvas id="cbm-accounts-chart" height="240"></canvas>';
+            }
+            echo '</div>';
+
+            echo '<div class="cbm-panel cbm-panel--elevated">';
+            echo '<h2>' . esc_html__( 'Reason Efficiency', 'codboost-money-manager' ) . '</h2>';
+            if ( empty( $reason_data ) ) {
+                echo '<p>' . esc_html__( 'Log transactions to understand which initiatives drive your performance.', 'codboost-money-manager' ) . '</p>';
+            } else {
+                echo '<canvas id="cbm-reason-chart" height="240"></canvas>';
             }
             echo '</div>';
             echo '</section>';
 
-            echo '<section class="cbm-panel">';
+            echo '<section class="cbm-grid cbm-grid--two">';
+            echo '<div class="cbm-panel">';
+            echo '<h2>' . esc_html__( 'Insights & Signals', 'codboost-money-manager' ) . '</h2>';
+            if ( empty( $insights ) ) {
+                echo '<p>' . esc_html__( 'Insights will appear after you import or log more transactions.', 'codboost-money-manager' ) . '</p>';
+            } else {
+                echo '<ul class="cbm-insights">';
+                foreach ( $insights as $insight ) {
+                    printf( '<li><strong>%1$s</strong><span>%2$s</span></li>', esc_html( $insight['title'] ), esc_html( $insight['detail'] ) );
+                }
+                echo '</ul>';
+            }
+            echo '</div>';
+
+            echo '<div class="cbm-panel">';
             echo '<h2>' . esc_html__( 'Recent Activity', 'codboost-money-manager' ) . '</h2>';
             if ( empty( $recent ) ) {
                 echo '<p>' . esc_html__( 'No transactions recorded yet.', 'codboost-money-manager' ) . '</p>';
             } else {
-                echo '<table class="cbm-table">';
+                echo '<table class="cbm-table cbm-table--compact">';
                 echo '<thead><tr>';
                 echo '<th>' . esc_html__( 'Date', 'codboost-money-manager' ) . '</th>';
                 echo '<th>' . esc_html__( 'Type', 'codboost-money-manager' ) . '</th>';
@@ -326,7 +453,7 @@ if ( ! class_exists( 'Codboost_Money_Manager' ) ) {
                         '<tr><td>%1$s</td><td class="cbm-pill cbm-pill--%6$s">%2$s</td><td>%3$s</td><td>%4$s</td><td>%5$s</td></tr>',
                         esc_html( date_i18n( get_option( 'date_format' ), strtotime( $row->transaction_date ) ) ),
                         esc_html( ucfirst( $row->transaction_type ) ),
-                        esc_html( $this->format_currency( $row->amount ) ),
+                        esc_html( $this->format_transaction_amount( (float) $row->amount, (string) $row->currency, (float) $row->exchange_rate ) ),
                         esc_html( $row->account_name ?: __( 'Unassigned', 'codboost-money-manager' ) ),
                         esc_html( $row->reason_name ?: __( 'Unassigned', 'codboost-money-manager' ) ),
                         esc_attr( $row->transaction_type )
@@ -334,6 +461,7 @@ if ( ! class_exists( 'Codboost_Money_Manager' ) ) {
                 }
                 echo '</tbody></table>';
             }
+            echo '</div>';
             echo '</section>';
         }
 
@@ -341,11 +469,16 @@ if ( ! class_exists( 'Codboost_Money_Manager' ) ) {
          * Render transactions tab with form + table.
          */
         protected function render_transactions_tab() : void {
-            $accounts   = $this->get_accounts();
-            $reasons    = $this->get_reasons();
-            $rows       = $this->get_transactions( 20 );
-            $form_url   = admin_url( 'admin-post.php' );
-            $delete_url = admin_url( 'admin-post.php' );
+            $accounts          = $this->get_accounts();
+            $reasons           = $this->get_reasons();
+            $rows              = $this->get_transactions( 20 );
+            $form_url          = admin_url( 'admin-post.php' );
+            $delete_url        = admin_url( 'admin-post.php' );
+            $status_breakdown  = $this->get_transaction_status_breakdown();
+            $default_currency  = $this->get_default_currency();
+            $status_options    = $this->get_transaction_statuses();
+            $currency_prefill  = strtoupper( $default_currency );
+            $exchange_prefill  = 1.0;
 
             echo '<section class="cbm-panel">';
             echo '<h2>' . esc_html__( 'Log New Transaction', 'codboost-money-manager' ) . '</h2>';
@@ -361,9 +494,16 @@ if ( ! class_exists( 'Codboost_Money_Manager' ) ) {
             echo $this->render_select_field( 'account_id', __( 'Account', 'codboost-money-manager' ), $this->convert_records_to_options( $accounts ) );
             echo $this->render_select_field( 'reason_id', __( 'Reason', 'codboost-money-manager' ), $this->convert_records_to_options( $reasons ) );
             echo $this->render_input_field( 'transaction_date', __( 'Date', 'codboost-money-manager' ), 'date', [ 'value' => wp_date( 'Y-m-d' ) ] );
+            echo $this->render_input_field( 'party', __( 'Stakeholder', 'codboost-money-manager' ), 'text', [ 'placeholder' => __( 'Client, vendor, or internal team', 'codboost-money-manager' ) ], false );
+            echo $this->render_input_field( 'reference', __( 'Reference ID', 'codboost-money-manager' ), 'text', [ 'placeholder' => __( 'Invoice, receipt, or project code', 'codboost-money-manager' ) ], false );
+            echo $this->render_select_field( 'status', __( 'Status', 'codboost-money-manager' ), $status_options, 'cleared' );
+            echo $this->render_input_field( 'currency', __( 'Currency', 'codboost-money-manager' ), 'text', [ 'maxlength' => '10', 'value' => $currency_prefill ], true );
+            echo $this->render_input_field( 'exchange_rate', __( 'Exchange Rate', 'codboost-money-manager' ), 'number', [ 'step' => '0.0001', 'min' => '0', 'value' => (string) $exchange_prefill ], true );
             echo '</div>';
-            echo $this->render_textarea_field( 'note', __( 'Notes (optional)', 'codboost-money-manager' ) );
-            echo '<button type="submit" class="button button-primary">' . esc_html__( 'Save Transaction', 'codboost-money-manager' ) . '</button>';
+            echo $this->render_textarea_field( 'note', __( 'Narrative (optional)', 'codboost-money-manager' ) );
+            echo $this->render_input_field( 'tags', __( 'Tags', 'codboost-money-manager' ), 'text', [ 'placeholder' => __( 'Comma separated insights: marketing, q1, renewal…', 'codboost-money-manager' ) ], false );
+            echo '<p class="cbm-form__hint">' . esc_html__( 'Amounts are stored in your base currency. Provide an exchange rate if the original currency differs.', 'codboost-money-manager' ) . '</p>';
+            echo '<button type="submit" class="button button-primary cbm-button--glow">' . esc_html__( 'Save Transaction', 'codboost-money-manager' ) . '</button>';
             echo '</form>';
             echo '</section>';
 
@@ -372,23 +512,40 @@ if ( ! class_exists( 'Codboost_Money_Manager' ) ) {
             if ( empty( $rows ) ) {
                 echo '<p>' . esc_html__( 'No transactions yet. Add your first entry above.', 'codboost-money-manager' ) . '</p>';
             } else {
-                echo '<table class="cbm-table">';
+                echo '<div class="cbm-badges">';
+                foreach ( $status_breakdown as $status => $count ) {
+                    printf(
+                        '<span class="cbm-status-pill"><strong>%1$s</strong> %2$s</span>',
+                        esc_html( $count ),
+                        esc_html( ucfirst( $status ) )
+                    );
+                }
+                echo '</div>';
+                echo '<table class="cbm-table cbm-table--responsive">';
                 echo '<thead><tr>';
                 echo '<th>' . esc_html__( 'Date', 'codboost-money-manager' ) . '</th>';
                 echo '<th>' . esc_html__( 'Type', 'codboost-money-manager' ) . '</th>';
+                echo '<th>' . esc_html__( 'Status', 'codboost-money-manager' ) . '</th>';
                 echo '<th>' . esc_html__( 'Amount', 'codboost-money-manager' ) . '</th>';
                 echo '<th>' . esc_html__( 'Account', 'codboost-money-manager' ) . '</th>';
                 echo '<th>' . esc_html__( 'Reason', 'codboost-money-manager' ) . '</th>';
-                echo '<th>' . esc_html__( 'Notes', 'codboost-money-manager' ) . '</th>';
+                echo '<th>' . esc_html__( 'Stakeholder', 'codboost-money-manager' ) . '</th>';
+                echo '<th>' . esc_html__( 'Reference', 'codboost-money-manager' ) . '</th>';
+                echo '<th>' . esc_html__( 'Tags', 'codboost-money-manager' ) . '</th>';
+                echo '<th>' . esc_html__( 'Narrative', 'codboost-money-manager' ) . '</th>';
                 echo '<th>' . esc_html__( 'Actions', 'codboost-money-manager' ) . '</th>';
                 echo '</tr></thead><tbody>';
                 foreach ( $rows as $row ) {
                     echo '<tr>';
                     echo '<td>' . esc_html( date_i18n( get_option( 'date_format' ), strtotime( $row->transaction_date ) ) ) . '</td>';
                     echo '<td><span class="cbm-pill cbm-pill--' . esc_attr( $row->transaction_type ) . '">' . esc_html( ucfirst( $row->transaction_type ) ) . '</span></td>';
-                    echo '<td>' . esc_html( $this->format_currency( $row->amount ) ) . '</td>';
+                    echo '<td>' . $this->render_status_badge( $row->status ) . '</td>';
+                    echo '<td>' . esc_html( $this->format_transaction_amount( (float) $row->amount, (string) $row->currency, (float) $row->exchange_rate ) ) . '</td>';
                     echo '<td>' . esc_html( $row->account_name ?: __( 'Unassigned', 'codboost-money-manager' ) ) . '</td>';
                     echo '<td>' . esc_html( $row->reason_name ?: __( 'Unassigned', 'codboost-money-manager' ) ) . '</td>';
+                    echo '<td>' . esc_html( $row->party ?: __( '—', 'codboost-money-manager' ) ) . '</td>';
+                    echo '<td>' . esc_html( $row->reference ?: __( '—', 'codboost-money-manager' ) ) . '</td>';
+                    echo '<td>' . $this->render_tag_badges( (string) $row->tags ) . '</td>';
                     echo '<td>' . esc_html( $row->note ) . '</td>';
                     echo '<td>';
                     printf(
@@ -512,6 +669,55 @@ if ( ! class_exists( 'Codboost_Money_Manager' ) ) {
         }
 
         /**
+         * Render setup tab for demo import and plugin checklist.
+         */
+        protected function render_setup_tab() : void {
+            $form_url          = admin_url( 'admin-post.php' );
+            $required_plugins  = $this->get_required_plugins();
+            $demo_already_used = (bool) get_option( self::DEMO_OPTION, false );
+
+            echo '<section class="cbm-grid cbm-grid--two">';
+            echo '<div class="cbm-panel cbm-panel--elevated">';
+            echo '<h2>' . esc_html__( 'Required Plugins', 'codboost-money-manager' ) . '</h2>';
+            echo '<p>' . esc_html__( 'Install these essentials to unlock the full Codboost finance experience.', 'codboost-money-manager' ) . '</p>';
+            echo '<ul class="cbm-plugin-checklist">';
+            foreach ( $required_plugins as $plugin ) {
+                $status  = $plugin['status'];
+                $classes = 'cbm-plugin-checklist__item ' . ( 'active' === $status ? 'is-active' : 'is-inactive' );
+                echo '<li class="' . esc_attr( $classes ) . '">';
+                echo '<div>'; 
+                echo '<strong>' . esc_html( $plugin['name'] ) . '</strong>';
+                if ( ! empty( $plugin['description'] ) ) {
+                    echo '<p>' . esc_html( $plugin['description'] ) . '</p>';
+                }
+                echo '</div>';
+                if ( 'active' !== $status && ! empty( $plugin['action'] ) ) {
+                    printf( '<a class="button" href="%1$s">%2$s</a>', esc_url( $plugin['action'] ), esc_html__( 'Install / Activate', 'codboost-money-manager' ) );
+                } else {
+                    echo '<span class="cbm-status-chip">' . esc_html__( 'Ready', 'codboost-money-manager' ) . '</span>';
+                }
+                echo '</li>';
+            }
+            echo '</ul>';
+            echo '</div>';
+
+            echo '<div class="cbm-panel cbm-panel--elevated">';
+            echo '<h2>' . esc_html__( 'One-Click Demo Data', 'codboost-money-manager' ) . '</h2>';
+            echo '<p>' . esc_html__( 'Import storytelling-ready accounts, reasons, and multi-channel transactions to explore analytics instantly.', 'codboost-money-manager' ) . '</p>';
+            echo '<form method="post" action="' . esc_url( $form_url ) . '">';
+            wp_nonce_field( self::NONCE_ACTION, '_cbm_nonce' );
+            echo '<input type="hidden" name="action" value="cmm_import_demo">';
+            if ( $demo_already_used ) {
+                echo '<p class="cbm-form__hint">' . esc_html__( 'Demo data was imported previously. Re-importing will append any missing records and refresh performance analytics.', 'codboost-money-manager' ) . '</p>';
+                echo '<label class="cbm-field cbm-field--inline"><input type="checkbox" name="force" value="1"> <span>' . esc_html__( 'Re-import demo data', 'codboost-money-manager' ) . '</span></label>';
+            }
+            echo '<button type="submit" class="button button-primary cbm-button--glow">' . esc_html__( 'Import Codboost Demo', 'codboost-money-manager' ) . '</button>';
+            echo '</form>';
+            echo '</div>';
+            echo '</section>';
+        }
+
+        /**
          * Handle account creation.
          */
         public function handle_save_account() : void {
@@ -609,6 +815,12 @@ if ( ! class_exists( 'Codboost_Money_Manager' ) ) {
             $reason_id        = isset( $_POST['reason_id'] ) ? absint( $_POST['reason_id'] ) : 0;
             $transaction_date = isset( $_POST['transaction_date'] ) ? sanitize_text_field( wp_unslash( $_POST['transaction_date'] ) ) : '';
             $note             = isset( $_POST['note'] ) ? sanitize_textarea_field( wp_unslash( $_POST['note'] ) ) : '';
+            $party            = isset( $_POST['party'] ) ? sanitize_text_field( wp_unslash( $_POST['party'] ) ) : '';
+            $reference        = isset( $_POST['reference'] ) ? sanitize_text_field( wp_unslash( $_POST['reference'] ) ) : '';
+            $status           = isset( $_POST['status'] ) ? sanitize_key( wp_unslash( $_POST['status'] ) ) : 'cleared';
+            $currency         = isset( $_POST['currency'] ) ? strtoupper( sanitize_text_field( wp_unslash( $_POST['currency'] ) ) ) : $this->get_default_currency();
+            $exchange_rate    = isset( $_POST['exchange_rate'] ) ? floatval( wp_unslash( $_POST['exchange_rate'] ) ) : 1;
+            $tags             = isset( $_POST['tags'] ) ? sanitize_text_field( wp_unslash( $_POST['tags'] ) ) : '';
 
             if ( $amount <= 0 ) {
                 $this->redirect_with_message( __( 'Amount must be greater than zero.', 'codboost-money-manager' ), 'error', 'transactions' );
@@ -616,6 +828,23 @@ if ( ! class_exists( 'Codboost_Money_Manager' ) ) {
 
             if ( ! in_array( $type, [ 'income', 'outcome' ], true ) ) {
                 $type = 'income';
+            }
+
+            $statuses = $this->get_transaction_statuses();
+            if ( ! array_key_exists( $status, $statuses ) ) {
+                $status = 'cleared';
+            }
+
+            if ( $exchange_rate <= 0 ) {
+                $exchange_rate = 1;
+            }
+
+            if ( empty( $currency ) ) {
+                $currency = $this->get_default_currency();
+            }
+
+            if ( strlen( $currency ) > 10 ) {
+                $currency = substr( $currency, 0, 10 );
             }
 
             $timestamp = $transaction_date ? strtotime( $transaction_date ) : false;
@@ -635,13 +864,26 @@ if ( ! class_exists( 'Codboost_Money_Manager' ) ) {
                 'account_id'       => $account_id ?: null,
                 'reason_id'        => $reason_id ?: null,
                 'note'             => $note,
+                'party'            => $party ?: null,
+                'reference'        => $reference ?: null,
+                'tags'             => $tags ?: null,
+                'currency'         => $currency,
+                'status'           => $status,
+                'exchange_rate'    => $exchange_rate,
                 'transaction_date' => $transaction_date,
+                'created_at'       => current_time( 'mysql' ),
             ], [
                 '%d',
                 '%s',
                 '%f',
                 '%d',
                 '%d',
+                '%s',
+                '%s',
+                '%s',
+                '%s',
+                '%s',
+                '%f',
                 '%s',
                 '%s',
             ] );
@@ -665,6 +907,32 @@ if ( ! class_exists( 'Codboost_Money_Manager' ) ) {
             $wpdb->delete( $transactions_table, [ 'id' => $transaction_id ], [ '%d' ] );
 
             $this->redirect_with_message( __( 'Transaction deleted.', 'codboost-money-manager' ), 'success', 'transactions' );
+        }
+
+        /**
+         * Handle demo data import.
+         */
+        public function handle_import_demo() : void {
+            $this->verify_permissions();
+
+            $force  = isset( $_POST['force'] ) && '1' === $_POST['force'];
+            $result = $this->import_demo_dataset( $force );
+
+            if ( ! empty( $result['error'] ) ) {
+                $this->redirect_with_message( $result['error'], 'error', 'setup' );
+            }
+
+            update_option( self::DEMO_OPTION, time() );
+
+            $message = sprintf(
+                /* translators: 1: number of accounts, 2: number of reasons, 3: number of transactions */
+                __( 'Imported %1$s accounts, %2$s reasons, and %3$s transactions ready for analytics.', 'codboost-money-manager' ),
+                number_format_i18n( (int) $result['accounts'] ),
+                number_format_i18n( (int) $result['reasons'] ),
+                number_format_i18n( (int) $result['transactions'] )
+            );
+
+            $this->redirect_with_message( $message, 'success', 'setup' );
         }
 
         /**
@@ -717,7 +985,7 @@ if ( ! class_exists( 'Codboost_Money_Manager' ) ) {
             global $wpdb;
             $table = $wpdb->prefix . 'cbm_transactions';
 
-            $results = $wpdb->get_results( "SELECT transaction_type, SUM(amount) AS total FROM {$table} GROUP BY transaction_type" );
+            $results = $wpdb->get_results( "SELECT transaction_type, SUM(amount * exchange_rate) AS total FROM {$table} GROUP BY transaction_type" );
             $totals  = [ 'income' => 0.0, 'outcome' => 0.0 ];
 
             foreach ( $results as $row ) {
@@ -725,6 +993,17 @@ if ( ! class_exists( 'Codboost_Money_Manager' ) ) {
             }
 
             $totals['balance'] = $totals['income'] - $totals['outcome'];
+            $totals['average_net'] = 0.0;
+
+            $chart_data = $this->get_chart_data();
+            if ( ! empty( $chart_data['net'] ) ) {
+                $valid_months = array_filter( $chart_data['net'], static function ( $value ) {
+                    return abs( (float) $value ) > 0.01;
+                } );
+                if ( ! empty( $valid_months ) ) {
+                    $totals['average_net'] = array_sum( $valid_months ) / count( $valid_months );
+                }
+            }
 
             return $totals;
         }
@@ -772,6 +1051,38 @@ if ( ! class_exists( 'Codboost_Money_Manager' ) ) {
         }
 
         /**
+         * Return required plugin checklist entries.
+         */
+        protected function get_required_plugins() : array {
+            include_once ABSPATH . 'wp-admin/includes/plugin.php';
+
+            $plugins = [];
+
+            $plugins[] = [
+                'name'        => __( 'Codboost Money Manager', 'codboost-money-manager' ),
+                'description' => __( 'Core plugin powering transactions, analytics, and the finance dashboard.', 'codboost-money-manager' ),
+                'status'      => 'active',
+                'action'      => '',
+            ];
+
+            $plugins[] = $this->resolve_plugin_state(
+                'wordpress-importer',
+                'wordpress-importer/wordpress-importer.php',
+                __( 'WordPress Importer', 'codboost-money-manager' ),
+                __( 'Allow importing additional demo templates or migrating data between sites.', 'codboost-money-manager' )
+            );
+
+            $plugins[] = $this->resolve_plugin_state(
+                'woocommerce',
+                'woocommerce/woocommerce.php',
+                __( 'WooCommerce', 'codboost-money-manager' ),
+                __( 'Provides enterprise-grade currency formatting and payment integrations.', 'codboost-money-manager' )
+            );
+
+            return apply_filters( 'codboost_money_manager_required_plugins', $plugins );
+        }
+
+        /**
          * Build chart data for JS.
          */
         protected function get_chart_data() : array {
@@ -783,12 +1094,16 @@ if ( ! class_exists( 'Codboost_Money_Manager' ) ) {
             $income_data = [];
             $out_data    = [];
 
+            $net_data        = [];
+            $cumulative_data = [];
+            $running_total   = 0.0;
+
             for ( $i = 11; $i >= 0; $i -- ) {
                 $month_key = gmdate( 'Y-m', strtotime( '-' . $i . ' months' ) );
                 $labels[]  = date_i18n( 'M Y', strtotime( $month_key . '-01' ) );
 
                 $prepared = $wpdb->prepare(
-                    "SELECT transaction_type, SUM(amount) as total
+                    "SELECT transaction_type, SUM(amount * exchange_rate) as total
                     FROM {$transactions_table}
                     WHERE DATE_FORMAT(transaction_date, '%%Y-%%m') = %s
                     GROUP BY transaction_type",
@@ -808,20 +1123,49 @@ if ( ! class_exists( 'Codboost_Money_Manager' ) ) {
                 }
                 $income_data[] = $income;
                 $out_data[]    = $outcome;
+                $net_value     = $income - $outcome;
+                $net_data[]    = $net_value;
+                $running_total += $net_value;
+                $cumulative_data[] = $running_total;
             }
 
             $accounts_distribution = $wpdb->get_results(
-                "SELECT a.name AS account, SUM(CASE WHEN t.transaction_type = 'income' THEN t.amount ELSE -t.amount END) AS balance
+                "SELECT a.name AS account, SUM(CASE WHEN t.transaction_type = 'income' THEN t.amount * t.exchange_rate ELSE -t.amount * t.exchange_rate END) AS balance
                 FROM {$transactions_table} t
                 LEFT JOIN {$accounts_table} a ON a.id = t.account_id
                 GROUP BY a.name"
             );
 
+            $reason_breakdown = $wpdb->get_results(
+                "SELECT COALESCE(r.name, 'Unassigned') AS reason,
+                    SUM(CASE WHEN t.transaction_type = 'income' THEN t.amount * t.exchange_rate ELSE 0 END) AS income_total,
+                    SUM(CASE WHEN t.transaction_type = 'outcome' THEN t.amount * t.exchange_rate ELSE 0 END) AS outcome_total
+                FROM {$transactions_table} t
+                LEFT JOIN {$reasons_table} r ON r.id = t.reason_id
+                GROUP BY r.name
+                ORDER BY income_total DESC"
+            );
+
+            $insights = $this->build_insights_from_chart( $labels, $net_data, $income_data, $out_data );
+
             return [
                 'labels'               => $labels,
                 'income'               => $income_data,
                 'outcome'              => $out_data,
+                'net'                  => $net_data,
+                'cumulative'           => $cumulative_data,
                 'accountsDistribution' => $accounts_distribution,
+                'reasonBreakdown'      => array_map( static function ( $row ) {
+                    $income  = (float) $row->income_total;
+                    $outcome = (float) $row->outcome_total;
+                    return [
+                        'reason' => (string) $row->reason,
+                        'income' => $income,
+                        'outcome' => $outcome,
+                        'net'    => $income - $outcome,
+                    ];
+                }, $reason_breakdown ?? [] ),
+                'insights'             => $insights,
             ];
         }
 
@@ -930,17 +1274,411 @@ if ( ! class_exists( 'Codboost_Money_Manager' ) ) {
         }
 
         /**
-         * Format currency helper.
+         * Describe plugin activation status for checklist UI.
          */
-        protected function format_currency( float $value ) : string {
-            $symbol = get_option( 'woocommerce_currency_symbol' );
-            if ( empty( $symbol ) ) {
-                $symbol = 'DZD';
+        protected function resolve_plugin_state( string $slug, string $plugin_file, string $name, string $description ) : array {
+            include_once ABSPATH . 'wp-admin/includes/plugin.php';
+
+            $plugin_path   = WP_PLUGIN_DIR . '/' . $plugin_file;
+            $is_installed  = file_exists( $plugin_path );
+            $is_active     = function_exists( 'is_plugin_active' ) && is_plugin_active( $plugin_file );
+            $status        = 'missing';
+            $action        = '';
+
+            if ( $is_active ) {
+                $status = 'active';
+            } elseif ( $is_installed ) {
+                $status = 'inactive';
+                $action = wp_nonce_url( self_admin_url( 'plugins.php?action=activate&plugin=' . $plugin_file ), 'activate-plugin_' . $plugin_file );
+            } else {
+                $status = 'missing';
+                $action = wp_nonce_url( self_admin_url( 'update.php?action=install-plugin&plugin=' . $slug ), 'install-plugin_' . $slug );
             }
 
-            $symbol = apply_filters( 'codboost_money_manager_currency_symbol', $symbol, $value );
+            return [
+                'name'        => $name,
+                'description' => $description,
+                'status'      => $status,
+                'action'      => $action,
+            ];
+        }
+
+        /**
+         * Import bundled demo dataset.
+         */
+        protected function import_demo_dataset( bool $force = false ) : array {
+            $file = plugin_dir_path( __FILE__ ) . 'data/demo-finance-data.json';
+
+            if ( ! file_exists( $file ) ) {
+                return [
+                    'accounts'     => 0,
+                    'reasons'      => 0,
+                    'transactions' => 0,
+                    'error'        => __( 'Demo data file is missing.', 'codboost-money-manager' ),
+                ];
+            }
+
+            $raw  = file_get_contents( $file );
+            $data = json_decode( (string) $raw, true );
+
+            if ( empty( $data ) || ! is_array( $data ) ) {
+                return [
+                    'accounts'     => 0,
+                    'reasons'      => 0,
+                    'transactions' => 0,
+                    'error'        => __( 'Demo dataset could not be parsed.', 'codboost-money-manager' ),
+                ];
+            }
+
+            $this->seed_default_terms();
+
+            global $wpdb;
+            $accounts_table     = $wpdb->prefix . 'cbm_accounts';
+            $reasons_table      = $wpdb->prefix . 'cbm_reasons';
+            $transactions_table = $wpdb->prefix . 'cbm_transactions';
+
+            $created = [ 'accounts' => 0, 'reasons' => 0, 'transactions' => 0, 'error' => '' ];
+
+            $accounts_map = [];
+            foreach ( $this->get_accounts() as $account ) {
+                $accounts_map[ strtolower( $account->name ) ] = (int) $account->id;
+            }
+
+            if ( ! empty( $data['accounts'] ) && is_array( $data['accounts'] ) ) {
+                foreach ( $data['accounts'] as $account ) {
+                    $name        = sanitize_text_field( $account['name'] ?? '' );
+                    $description = sanitize_textarea_field( $account['description'] ?? '' );
+                    if ( empty( $name ) ) {
+                        continue;
+                    }
+
+                    $key = strtolower( $name );
+                    if ( isset( $accounts_map[ $key ] ) ) {
+                        continue;
+                    }
+
+                    $wpdb->insert( $accounts_table, [
+                        'name'        => $name,
+                        'description' => $description,
+                    ] );
+                    $accounts_map[ $key ] = (int) $wpdb->insert_id;
+                    $created['accounts'] ++;
+                }
+            }
+
+            $reasons_map = [];
+            foreach ( $this->get_reasons() as $reason ) {
+                $reasons_map[ strtolower( $reason->name ) ] = (int) $reason->id;
+            }
+
+            if ( ! empty( $data['reasons'] ) && is_array( $data['reasons'] ) ) {
+                foreach ( $data['reasons'] as $reason ) {
+                    $name        = sanitize_text_field( $reason['name'] ?? '' );
+                    $description = sanitize_textarea_field( $reason['description'] ?? '' );
+                    $type        = sanitize_key( $reason['type'] ?? 'general' );
+                    if ( empty( $name ) ) {
+                        continue;
+                    }
+
+                    $key = strtolower( $name );
+                    if ( isset( $reasons_map[ $key ] ) ) {
+                        continue;
+                    }
+
+                    if ( ! in_array( $type, [ 'income', 'outcome', 'general' ], true ) ) {
+                        $type = 'general';
+                    }
+
+                    $wpdb->insert( $reasons_table, [
+                        'name'        => $name,
+                        'type'        => $type,
+                        'description' => $description,
+                    ] );
+                    $reasons_map[ $key ] = (int) $wpdb->insert_id;
+                    $created['reasons'] ++;
+                }
+            }
+
+            if ( empty( $data['transactions'] ) || ! is_array( $data['transactions'] ) ) {
+                return $created;
+            }
+
+            if ( ! $force ) {
+                $existing = (int) $wpdb->get_var( "SELECT COUNT(id) FROM {$transactions_table}" );
+                if ( $existing > 0 ) {
+                    $created['transactions'] = 0;
+                    $created['error']        = __( 'Demo data skipped because transactions already exist. Enable re-import to append the scenario.', 'codboost-money-manager' );
+                    return $created;
+                }
+            }
+
+            foreach ( $data['transactions'] as $transaction ) {
+                $type          = sanitize_key( $transaction['type'] ?? 'income' );
+                $amount        = isset( $transaction['amount'] ) ? (float) $transaction['amount'] : 0.0;
+                $currency      = strtoupper( sanitize_text_field( $transaction['currency'] ?? $this->get_default_currency() ) );
+                $exchange_rate = isset( $transaction['exchange_rate'] ) ? (float) $transaction['exchange_rate'] : 1.0;
+                $status        = sanitize_key( $transaction['status'] ?? 'cleared' );
+                $note          = sanitize_textarea_field( $transaction['note'] ?? '' );
+                $party         = sanitize_text_field( $transaction['party'] ?? '' );
+                $reference     = sanitize_text_field( $transaction['reference'] ?? '' );
+                $tags          = sanitize_text_field( $transaction['tags'] ?? '' );
+                $account_name  = isset( $transaction['account'] ) ? strtolower( sanitize_text_field( $transaction['account'] ) ) : '';
+                $reason_name   = isset( $transaction['reason'] ) ? strtolower( sanitize_text_field( $transaction['reason'] ) ) : '';
+                $date_string   = sanitize_text_field( $transaction['date'] ?? '' );
+
+                if ( $amount <= 0 ) {
+                    continue;
+                }
+
+                if ( ! in_array( $type, [ 'income', 'outcome' ], true ) ) {
+                    $type = 'income';
+                }
+
+                $statuses = $this->get_transaction_statuses();
+                if ( ! array_key_exists( $status, $statuses ) ) {
+                    $status = 'cleared';
+                }
+
+                $account_id = $account_name && isset( $accounts_map[ $account_name ] ) ? $accounts_map[ $account_name ] : null;
+                $reason_id  = $reason_name && isset( $reasons_map[ $reason_name ] ) ? $reasons_map[ $reason_name ] : null;
+
+                $timestamp = strtotime( $date_string );
+                $date      = $timestamp ? wp_date( 'Y-m-d', $timestamp ) : wp_date( 'Y-m-d' );
+
+                $wpdb->insert( $transactions_table, [
+                    'user_id'          => get_current_user_id(),
+                    'transaction_type' => $type,
+                    'amount'           => $amount,
+                    'account_id'       => $account_id,
+                    'reason_id'        => $reason_id,
+                    'note'             => $note,
+                    'party'            => $party ?: null,
+                    'reference'        => $reference ?: null,
+                    'tags'             => $tags ?: null,
+                    'currency'         => $currency ?: $this->get_default_currency(),
+                    'status'           => $status,
+                    'exchange_rate'    => $exchange_rate > 0 ? $exchange_rate : 1,
+                    'transaction_date' => $date,
+                    'created_at'       => current_time( 'mysql' ),
+                ] );
+
+                $created['transactions'] ++;
+            }
+
+            return $created;
+        }
+
+        /**
+         * Format currency helper.
+         */
+        protected function format_currency( float $value, string $currency = '' ) : string {
+            $currency = $currency ?: $this->get_default_currency();
+            $symbol   = $this->get_currency_symbol( $currency );
 
             return sprintf( '%s %s', $symbol, number_format_i18n( $value, 2 ) );
+        }
+
+        /**
+         * Format amounts for display, including original currency if different.
+         */
+        protected function format_transaction_amount( float $amount, string $currency, float $exchange_rate ) : string {
+            $currency      = $currency ? strtoupper( $currency ) : $this->get_default_currency();
+            $base_currency = $this->get_default_currency();
+            $exchange_rate = $exchange_rate > 0 ? $exchange_rate : 1;
+            $base_value    = $amount * $exchange_rate;
+
+            $display = $this->format_currency( $base_value, $base_currency );
+
+            if ( $currency !== $base_currency ) {
+                $display .= sprintf(
+                    ' (%1$s %2$s @ %3$s)',
+                    $currency,
+                    number_format_i18n( $amount, 2 ),
+                    number_format_i18n( $exchange_rate, 3 )
+                );
+            }
+
+            return $display;
+        }
+
+        /**
+         * Determine default currency.
+         */
+        protected function get_default_currency() : string {
+            $currency = get_option( 'woocommerce_currency' );
+            if ( empty( $currency ) ) {
+                $currency = 'DZD';
+            }
+
+            $currency = apply_filters( 'codboost_money_manager_default_currency', $currency );
+
+            return strtoupper( (string) $currency );
+        }
+
+        /**
+         * Resolve currency symbol for display.
+         */
+        protected function get_currency_symbol( string $currency ) : string {
+            $currency = strtoupper( $currency );
+
+            if ( function_exists( 'get_woocommerce_currency_symbol' ) ) {
+                $symbol = get_woocommerce_currency_symbol( $currency );
+                if ( $symbol ) {
+                    return (string) $symbol;
+                }
+            }
+
+            $fallback = [
+                'DZD' => 'DA',
+                'USD' => '$',
+                'EUR' => '€',
+                'GBP' => '£',
+                'CAD' => 'C$',
+                'AUD' => 'A$',
+                'SAR' => '﷼',
+                'AED' => 'د.إ',
+            ];
+
+            $symbol = $fallback[ $currency ] ?? $currency;
+
+            return apply_filters( 'codboost_money_manager_currency_symbol', $symbol, $currency );
+        }
+
+        /**
+         * Compute status options.
+         */
+        protected function get_transaction_statuses() : array {
+            $statuses = [
+                'cleared'   => __( 'Cleared', 'codboost-money-manager' ),
+                'pending'   => __( 'Pending', 'codboost-money-manager' ),
+                'scheduled' => __( 'Scheduled', 'codboost-money-manager' ),
+                'disputed'  => __( 'Disputed', 'codboost-money-manager' ),
+            ];
+
+            return apply_filters( 'codboost_money_manager_statuses', $statuses );
+        }
+
+        /**
+         * Aggregate status counts for the dashboard.
+         */
+        protected function get_transaction_status_breakdown() : array {
+            global $wpdb;
+            $table    = $wpdb->prefix . 'cbm_transactions';
+            $statuses = array_fill_keys( array_keys( $this->get_transaction_statuses() ), 0 );
+
+            $results = $wpdb->get_results( "SELECT status, COUNT(id) AS total FROM {$table} GROUP BY status" );
+            foreach ( $results as $row ) {
+                $key = sanitize_key( $row->status );
+                if ( isset( $statuses[ $key ] ) ) {
+                    $statuses[ $key ] = (int) $row->total;
+                }
+            }
+
+            return $statuses;
+        }
+
+        /**
+         * Render status badge HTML.
+         */
+        protected function render_status_badge( ?string $status ) : string {
+            $status  = $status ? sanitize_key( $status ) : 'cleared';
+            $labels  = $this->get_transaction_statuses();
+            $label   = $labels[ $status ] ?? ucfirst( $status );
+
+            return '<span class="cbm-status cbm-status--' . esc_attr( $status ) . '">' . esc_html( $label ) . '</span>';
+        }
+
+        /**
+         * Render tag chips from comma separated list.
+         */
+        protected function render_tag_badges( string $tags ) : string {
+            $parts = array_filter( array_map( 'trim', explode( ',', $tags ) ) );
+
+            if ( empty( $parts ) ) {
+                return '<span class="cbm-muted">' . esc_html__( '—', 'codboost-money-manager' ) . '</span>';
+            }
+
+            $html = '<span class="cbm-tags">';
+            foreach ( $parts as $tag ) {
+                $html .= '<span class="cbm-tag">' . esc_html( $tag ) . '</span>';
+            }
+            $html .= '</span>';
+
+            return $html;
+        }
+
+        /**
+         * Compose story-driven insights from monthly data.
+         */
+        protected function build_insights_from_chart( array $labels, array $net, array $income, array $outcome ) : array {
+            $insights = [];
+
+            if ( empty( $net ) ) {
+                return $insights;
+            }
+
+            $base_currency = $this->get_default_currency();
+
+            $max_net   = max( $net );
+            $min_net   = min( $net );
+            $max_index = array_search( $max_net, $net, true );
+            $min_index = array_search( $min_net, $net, true );
+
+            if ( false !== $max_index && isset( $labels[ $max_index ] ) ) {
+                $insights[] = [
+                    'title'  => __( 'Best Month', 'codboost-money-manager' ),
+                    'detail' => sprintf(
+                        /* translators: 1: month label, 2: amount */
+                        __( '%1$s delivered %2$s net contribution.', 'codboost-money-manager' ),
+                        $labels[ $max_index ],
+                        $this->format_currency( $max_net, $base_currency )
+                    ),
+                ];
+            }
+
+            if ( false !== $min_index && isset( $labels[ $min_index ] ) ) {
+                $insights[] = [
+                    'title'  => __( 'Pressure Point', 'codboost-money-manager' ),
+                    'detail' => sprintf(
+                        __( '%1$s saw a %2$s dip — review spending or pricing.', 'codboost-money-manager' ),
+                        $labels[ $min_index ],
+                        $this->format_currency( abs( $min_net ), $base_currency )
+                    ),
+                ];
+            }
+
+            $recent_net    = end( $net );
+            $previous_net  = count( $net ) > 1 ? $net[ count( $net ) - 2 ] : 0;
+            $momentum_diff = $recent_net - $previous_net;
+            $momentum_copy = $momentum_diff >= 0
+                ? sprintf( __( 'Momentum up %s vs last month.', 'codboost-money-manager' ), $this->format_currency( $momentum_diff, $base_currency ) )
+                : sprintf( __( 'Momentum down %s vs last month.', 'codboost-money-manager' ), $this->format_currency( abs( $momentum_diff ), $base_currency ) );
+            $insights[]     = [
+                'title'  => __( 'Momentum', 'codboost-money-manager' ),
+                'detail' => $momentum_copy,
+            ];
+
+            $income_months = array_filter( $income, static function ( $value ) {
+                return abs( (float) $value ) > 0.01;
+            } );
+            $out_months = array_filter( $outcome, static function ( $value ) {
+                return abs( (float) $value ) > 0.01;
+            } );
+
+            if ( ! empty( $income_months ) ) {
+                $avg_income  = array_sum( $income_months ) / count( $income_months );
+                $avg_outcome = ! empty( $out_months ) ? array_sum( $out_months ) / count( $out_months ) : 0;
+                $insights[]  = [
+                    'title'  => __( 'Monthly Run Rate', 'codboost-money-manager' ),
+                    'detail' => sprintf(
+                        __( '%1$s inflow vs %2$s outflow on average.', 'codboost-money-manager' ),
+                        $this->format_currency( $avg_income, $base_currency ),
+                        $this->format_currency( $avg_outcome, $base_currency )
+                    ),
+                ];
+            }
+
+            return $insights;
         }
 
         /**

--- a/data/demo-finance-data.json
+++ b/data/demo-finance-data.json
@@ -1,0 +1,189 @@
+{
+  "accounts": [
+    {
+      "name": "Cash Wallet",
+      "description": "Retail petty cash float for on-the-go expenses."
+    },
+    {
+      "name": "Baridi Mob",
+      "description": "Primary mobile payment wallet used for quick settlements."
+    },
+    {
+      "name": "BNP Operations",
+      "description": "Bank account capturing invoiced revenue and payroll runs."
+    },
+    {
+      "name": "Marketing Budget",
+      "description": "Dedicated allocation for growth and community initiatives."
+    }
+  ],
+  "reasons": [
+    {
+      "name": "SaaS Subscriptions",
+      "type": "income",
+      "description": "Recurring Codboost platform subscriptions."
+    },
+    {
+      "name": "Enterprise Deployment",
+      "type": "income",
+      "description": "One-off deployment project for enterprise clients."
+    },
+    {
+      "name": "Talent Payroll",
+      "type": "outcome",
+      "description": "Team salaries, bonuses, and consultant fees."
+    },
+    {
+      "name": "Growth Experiments",
+      "type": "outcome",
+      "description": "Paid campaigns, events, and customer acquisition tests."
+    },
+    {
+      "name": "Product Innovation",
+      "type": "general",
+      "description": "Research and product exploration initiatives."
+    }
+  ],
+  "transactions": [
+    {
+      "type": "income",
+      "amount": 4200,
+      "currency": "EUR",
+      "exchange_rate": 147.6,
+      "status": "cleared",
+      "note": "Q1 SaaS renewal from premium client",
+      "party": "TechNova SA",
+      "reference": "INV-2024-001",
+      "tags": "renewal, q1, enterprise",
+      "account": "BNP Operations",
+      "reason": "SaaS Subscriptions",
+      "date": "2024-01-12"
+    },
+    {
+      "type": "income",
+      "amount": 1850,
+      "currency": "USD",
+      "exchange_rate": 134.8,
+      "status": "scheduled",
+      "note": "Discovery sprint deposit",
+      "party": "Atlas Industries",
+      "reference": "PO-5581",
+      "tags": "sprint, discovery",
+      "account": "BNP Operations",
+      "reason": "Enterprise Deployment",
+      "date": "2024-02-05"
+    },
+    {
+      "type": "outcome",
+      "amount": 950000,
+      "currency": "DZD",
+      "exchange_rate": 1,
+      "status": "cleared",
+      "note": "January payroll run",
+      "party": "Codboost Team",
+      "reference": "PAY-2024-01",
+      "tags": "payroll, hr",
+      "account": "BNP Operations",
+      "reason": "Talent Payroll",
+      "date": "2024-01-28"
+    },
+    {
+      "type": "outcome",
+      "amount": 420000,
+      "currency": "DZD",
+      "exchange_rate": 1,
+      "status": "pending",
+      "note": "Growth marketing experiments",
+      "party": "AdCreative Co",
+      "reference": "GRW-8891",
+      "tags": "marketing, campaign",
+      "account": "Marketing Budget",
+      "reason": "Growth Experiments",
+      "date": "2024-02-10"
+    },
+    {
+      "type": "income",
+      "amount": 2100,
+      "currency": "EUR",
+      "exchange_rate": 146.2,
+      "status": "cleared",
+      "note": "Accelerator partner onboarding",
+      "party": "NorthBridge Accelerator",
+      "reference": "INV-2024-014",
+      "tags": "partner, onboarding",
+      "account": "BNP Operations",
+      "reason": "Enterprise Deployment",
+      "date": "2024-03-02"
+    },
+    {
+      "type": "outcome",
+      "amount": 180000,
+      "currency": "DZD",
+      "exchange_rate": 1,
+      "status": "disputed",
+      "note": "Experimental AI tool subscription",
+      "party": "AI Labs",
+      "reference": "SUB-AL-02",
+      "tags": "innovation, tooling",
+      "account": "Cash Wallet",
+      "reason": "Product Innovation",
+      "date": "2024-03-15"
+    },
+    {
+      "type": "income",
+      "amount": 1150,
+      "currency": "USD",
+      "exchange_rate": 135.2,
+      "status": "cleared",
+      "note": "Monthly SaaS billing",
+      "party": "Visionary Retail",
+      "reference": "INV-2024-020",
+      "tags": "subscription, retail",
+      "account": "BNP Operations",
+      "reason": "SaaS Subscriptions",
+      "date": "2024-03-20"
+    },
+    {
+      "type": "outcome",
+      "amount": 220000,
+      "currency": "DZD",
+      "exchange_rate": 1,
+      "status": "scheduled",
+      "note": "Community hackathon sponsorship",
+      "party": "Codboost Community",
+      "reference": "EVT-2024-07",
+      "tags": "community, event",
+      "account": "Marketing Budget",
+      "reason": "Growth Experiments",
+      "date": "2024-04-05"
+    },
+    {
+      "type": "income",
+      "amount": 3600,
+      "currency": "EUR",
+      "exchange_rate": 145.1,
+      "status": "cleared",
+      "note": "Annual platform renewal",
+      "party": "Bluewave Media",
+      "reference": "INV-2024-034",
+      "tags": "renewal, annual",
+      "account": "BNP Operations",
+      "reason": "SaaS Subscriptions",
+      "date": "2024-04-18"
+    },
+    {
+      "type": "outcome",
+      "amount": 620000,
+      "currency": "DZD",
+      "exchange_rate": 1,
+      "status": "cleared",
+      "note": "April payroll run",
+      "party": "Codboost Team",
+      "reference": "PAY-2024-04",
+      "tags": "payroll, hr",
+      "account": "BNP Operations",
+      "reason": "Talent Payroll",
+      "date": "2024-04-28"
+    }
+  ]
+}

--- a/wp-content/themes/codboost-finance/assets/css/components.css
+++ b/wp-content/themes/codboost-finance/assets/css/components.css
@@ -1,28 +1,49 @@
 .money-manager-wrapper {
-    margin-top: 2rem;
+    margin-top: 2.5rem;
+    position: relative;
+}
+
+.money-manager-wrapper::before {
+    content: '';
+    position: absolute;
+    inset: -40px 10% auto 10%;
+    height: 240px;
+    background: radial-gradient(circle, rgba(17, 20, 255, 0.18), transparent 70%);
+    filter: blur(40px);
+    z-index: 0;
 }
 
 .money-manager-wrapper .codboost-money-manager {
+    position: relative;
+    z-index: 1;
     background: transparent;
 }
 
 .money-manager-wrapper .cbm-panel {
-    background: rgba(255, 255, 255, 0.9);
+    background: rgba(255, 255, 255, 0.94);
+}
+
+.money-manager-wrapper .cbm-panel--elevated::after {
+    background: radial-gradient(circle at top left, rgba(215, 255, 0, 0.25), transparent 60%);
 }
 
 .money-manager-wrapper .cbm-card {
-    background: rgba(215, 255, 0, 0.12);
+    background: linear-gradient(135deg, rgba(215, 255, 0, 0.12), rgba(255, 255, 255, 0.9));
     border-left-color: #d7ff00;
 }
 
 .money-manager-wrapper .cbm-card--income {
-    border-left-color: #0f766e;
+    border-left-color: #16a34a;
 }
 
 .money-manager-wrapper .cbm-card--outcome {
-    border-left-color: #dc2626;
+    border-left-color: #ef4444;
 }
 
 .money-manager-wrapper .cbm-card--balance {
-    border-left-color: #1114ff;
+    border-left-color: #1414ff;
+}
+
+.money-manager-wrapper .cbm-card--trend {
+    border-left-color: #d7ff00;
 }

--- a/wp-content/themes/codboost-finance/assets/css/components.css
+++ b/wp-content/themes/codboost-finance/assets/css/components.css
@@ -1,0 +1,28 @@
+.money-manager-wrapper {
+    margin-top: 2rem;
+}
+
+.money-manager-wrapper .codboost-money-manager {
+    background: transparent;
+}
+
+.money-manager-wrapper .cbm-panel {
+    background: rgba(255, 255, 255, 0.9);
+}
+
+.money-manager-wrapper .cbm-card {
+    background: rgba(215, 255, 0, 0.12);
+    border-left-color: #d7ff00;
+}
+
+.money-manager-wrapper .cbm-card--income {
+    border-left-color: #0f766e;
+}
+
+.money-manager-wrapper .cbm-card--outcome {
+    border-left-color: #dc2626;
+}
+
+.money-manager-wrapper .cbm-card--balance {
+    border-left-color: #1114ff;
+}

--- a/wp-content/themes/codboost-finance/assets/img/codboost-logo-light.svg
+++ b/wp-content/themes/codboost-finance/assets/img/codboost-logo-light.svg
@@ -1,0 +1,5 @@
+<svg width="240" height="72" viewBox="0 0 240 72" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <rect width="240" height="72" rx="18" fill="#0F172A"/>
+  <path d="M32 20C24 20 18 26.268 18 36C18 45.732 24 52 32 52H46V44H32C28 44 26 41 26 36C26 31 28 28 32 28H46V20H32Z" fill="#D7FF00"/>
+  <text x="64" y="45" fill="white" font-family="'Inter', sans-serif" font-size="26" font-weight="700">Codboost</text>
+</svg>

--- a/wp-content/themes/codboost-finance/footer.php
+++ b/wp-content/themes/codboost-finance/footer.php
@@ -1,0 +1,3 @@
+<?php wp_footer(); ?>
+</body>
+</html>

--- a/wp-content/themes/codboost-finance/functions.php
+++ b/wp-content/themes/codboost-finance/functions.php
@@ -1,0 +1,57 @@
+<?php
+/**
+ * Theme bootstrap for Codboost Finance Portal.
+ */
+
+declare( strict_types=1 );
+
+add_action( 'after_setup_theme', function () : void {
+    add_theme_support( 'title-tag' );
+    add_theme_support( 'post-thumbnails' );
+    add_theme_support( 'automatic-feed-links' );
+    register_nav_menus( [
+        'primary' => __( 'Primary Menu', 'codboost-finance' ),
+    ] );
+} );
+
+add_action( 'wp_enqueue_scripts', function () : void {
+    wp_enqueue_style( 'codboost-finance-style', get_stylesheet_uri(), [], '1.0.0' );
+    wp_enqueue_style( 'codboost-finance-components', get_theme_file_uri( 'assets/css/components.css' ), [ 'codboost-finance-style' ], '1.0.0' );
+} );
+
+add_action( 'login_enqueue_scripts', function () : void {
+    wp_enqueue_style( 'codboost-finance-style', get_stylesheet_uri(), [], '1.0.0' );
+    echo '<style>body.login{background:linear-gradient(135deg,#0f172a 0%,#1114ff 100%);} .login h1 a{background-image:url(' . esc_url( get_theme_file_uri( 'assets/img/codboost-logo-light.svg' ) ) . ');background-size:contain;width:180px;height:60px;}</style>';
+} );
+
+add_action( 'after_switch_theme', function () : void {
+    $page_id = (int) get_option( 'codboost_finance_dashboard_page', 0 );
+    if ( $page_id && 'publish' === get_post_status( $page_id ) ) {
+        return;
+    }
+
+    $page_id = wp_insert_post( [
+        'post_title'   => __( 'Finance Dashboard', 'codboost-finance' ),
+        'post_status'  => 'publish',
+        'post_type'    => 'page',
+        'post_content' => '',
+    ] );
+
+    if ( ! is_wp_error( $page_id ) ) {
+        update_post_meta( $page_id, '_wp_page_template', 'page-money-manager.php' );
+        update_option( 'codboost_finance_dashboard_page', $page_id );
+    }
+} );
+
+/**
+ * Helper to embed the money manager automatically when the plugin is active.
+ */
+add_filter( 'the_content', function ( string $content ) : string {
+    if ( is_page_template( 'page-money-manager.php' ) && class_exists( 'Codboost_Money_Manager' ) ) {
+        if ( false === strpos( $content, '[codboost_money_manager]' ) ) {
+            $content .= '\n[codboost_money_manager]';
+        }
+    }
+
+    return $content;
+} );

--- a/wp-content/themes/codboost-finance/functions.php
+++ b/wp-content/themes/codboost-finance/functions.php
@@ -55,3 +55,41 @@ add_filter( 'the_content', function ( string $content ) : string {
 
     return $content;
 } );
+
+add_action( 'admin_notices', function () : void {
+    if ( ! current_user_can( 'manage_options' ) ) {
+        return;
+    }
+
+    $screen = function_exists( 'get_current_screen' ) ? get_current_screen() : null;
+    if ( $screen && 'dashboard' !== $screen->id && 'toplevel_page_codboost-money-manager' !== $screen->id ) {
+        return;
+    }
+
+    if ( ! class_exists( 'Codboost_Money_Manager' ) ) {
+        echo '<div class="notice notice-warning"><p>' . wp_kses_post( sprintf(
+            /* translators: %s is a link */
+            __( 'Activate the Codboost Money Manager plugin to unlock the finance dashboard. %s', 'codboost-finance' ),
+            '<a href="' . esc_url( admin_url( 'plugins.php' ) ) . '">' . esc_html__( 'Activate now', 'codboost-finance' ) . '</a>'
+        ) ) . '</p></div>';
+        return;
+    }
+
+    if ( get_option( 'codboost_money_manager_demo_seeded' ) ) {
+        return;
+    }
+
+    $link = add_query_arg(
+        [
+            'page' => 'codboost-money-manager',
+            'tab'  => 'setup',
+        ],
+        admin_url( 'admin.php' )
+    );
+
+    echo '<div class="notice notice-info is-dismissible"><p>' . wp_kses_post( sprintf(
+        /* translators: %s is a link */
+        __( 'Import the Codboost finance demo data to explore analytics instantly. %s', 'codboost-finance' ),
+        '<a href="' . esc_url( $link ) . '">' . esc_html__( 'Launch setup', 'codboost-finance' ) . '</a>'
+    ) ) . '</p></div>';
+} );

--- a/wp-content/themes/codboost-finance/header.php
+++ b/wp-content/themes/codboost-finance/header.php
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html <?php language_attributes(); ?>>
+<head>
+    <meta charset="<?php bloginfo( 'charset' ); ?>">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <?php wp_head(); ?>
+</head>
+<body <?php body_class(); ?>>
+<?php wp_body_open(); ?>

--- a/wp-content/themes/codboost-finance/index.php
+++ b/wp-content/themes/codboost-finance/index.php
@@ -1,0 +1,50 @@
+<?php
+/**
+ * Main template file for Codboost Finance Portal.
+ *
+ * @package CodboostFinance
+ */
+
+declare( strict_types=1 );
+
+get_header();
+?>
+
+<main class="site-wrapper">
+    <section class="site-hero">
+        <h1><?php echo esc_html__( 'Codboost Finance Control Center', 'codboost-finance' ); ?></h1>
+        <p><?php echo esc_html__( 'Monitor balances, track every transaction, and collaborate with your team through a unified financial cockpit.', 'codboost-finance' ); ?></p>
+        <?php if ( is_user_logged_in() ) :
+            $dashboard_id   = (int) get_option( 'codboost_finance_dashboard_page' );
+            $dashboard_link = $dashboard_id ? get_permalink( $dashboard_id ) : admin_url( 'admin.php?page=codboost-money-manager' );
+        ?>
+            <a class="cta" href="<?php echo esc_url( $dashboard_link ); ?>">
+                <?php echo esc_html__( 'Open my dashboard', 'codboost-finance' ); ?>
+            </a>
+        <?php else : ?>
+            <a class="cta" href="<?php echo esc_url( wp_login_url() ); ?>">
+                <?php echo esc_html__( 'Login to manage finances', 'codboost-finance' ); ?>
+            </a>
+        <?php endif; ?>
+    </section>
+
+    <section class="site-content">
+        <?php
+        if ( have_posts() ) {
+            while ( have_posts() ) {
+                the_post();
+                the_content();
+            }
+        } else {
+            echo '<p>' . esc_html__( 'Create a page and assign the “Codboost Money Manager Dashboard” template to display financial analytics.', 'codboost-finance' ) . '</p>';
+        }
+        ?>
+    </section>
+
+    <footer class="site-footer">
+        <?php echo esc_html__( 'Codboost — Let’s take your brand to the next level.', 'codboost-finance' ); ?>
+    </footer>
+</main>
+
+<?php
+get_footer();

--- a/wp-content/themes/codboost-finance/page-money-manager.php
+++ b/wp-content/themes/codboost-finance/page-money-manager.php
@@ -1,0 +1,33 @@
+<?php
+/**
+ * Template Name: Codboost Money Manager Dashboard
+ * Description: Displays the Codboost Money Manager interface for authenticated users.
+ *
+ * @package CodboostFinance
+ */
+
+declare( strict_types=1 );
+
+global $post;
+
+get_header();
+?>
+
+<main class="site-wrapper">
+    <section class="site-hero">
+        <h1><?php the_title(); ?></h1>
+        <p><?php echo esc_html__( 'A secure workspace to capture income, monitor expenses, and keep track of Codboost financial health.', 'codboost-finance' ); ?></p>
+    </section>
+
+    <section class="site-content money-manager-wrapper">
+        <?php
+        while ( have_posts() ) {
+            the_post();
+            the_content();
+        }
+        ?>
+    </section>
+</main>
+
+<?php
+get_footer();

--- a/wp-content/themes/codboost-finance/style.css
+++ b/wp-content/themes/codboost-finance/style.css
@@ -4,24 +4,25 @@ Theme URI: https://codboost.pro/
 Author: Codboost
 Author URI: https://codboost.pro/
 Description: Tailored UI/UX theme for the Codboost money management experience.
-Version: 1.0.0
+Version: 1.1.0
 License: GNU General Public License v2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 Text Domain: codboost-finance
 */
 
-@import url('https://fonts.googleapis.com/css2?family=Inter:wght@400;600;700&display=swap');
+@import url('https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap');
 
 body {
     margin: 0;
     font-family: 'Inter', -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
-    background: linear-gradient(135deg, #0f172a 0%, #1114ff 100%);
+    background: radial-gradient(circle at top, rgba(17, 20, 255, 0.65), rgba(15, 23, 42, 0.92));
     min-height: 100vh;
     color: #0f172a;
 }
 
 a {
     color: #d7ff00;
+    text-decoration: none;
 }
 
 a:hover {
@@ -29,76 +30,113 @@ a:hover {
 }
 
 .site-wrapper {
-    max-width: 1080px;
+    max-width: 1160px;
     margin: 0 auto;
-    padding: 3rem 1.5rem 4rem;
+    padding: 3.5rem 1.75rem 4.5rem;
 }
 
 .site-hero {
-    background: rgba(255, 255, 255, 0.08);
-    border-radius: 2rem;
-    padding: 2.5rem;
+    position: relative;
+    background: linear-gradient(135deg, rgba(255, 255, 255, 0.08), rgba(17, 20, 255, 0.35));
+    border-radius: 2.5rem;
+    padding: 3rem;
     text-align: center;
     color: #fff;
-    box-shadow: 0 30px 60px rgba(15, 23, 42, 0.45);
+    box-shadow: 0 40px 80px rgba(15, 23, 42, 0.45);
+    overflow: hidden;
+}
+
+.site-hero::after {
+    content: '';
+    position: absolute;
+    width: 360px;
+    height: 360px;
+    background: url('https://money.codboost.pro/wp-content/uploads/2025/10/codboost.png') no-repeat center/contain;
+    top: -40px;
+    right: -40px;
+    opacity: 0.12;
+    animation: heroFloat 10s ease-in-out infinite;
+}
+
+.site-hero::before {
+    content: '';
+    position: absolute;
+    inset: 20% -20% -50% -20%;
+    background: radial-gradient(circle, rgba(215, 255, 0, 0.25), transparent 65%);
+    opacity: 0.45;
 }
 
 .site-hero h1 {
-    font-size: 2.8rem;
+    font-size: 3rem;
     margin: 0 0 1rem;
     letter-spacing: -0.02em;
 }
 
 .site-hero p {
     font-size: 1.1rem;
-    margin: 0 auto 2rem;
-    max-width: 640px;
+    margin: 0 auto 2.4rem;
+    max-width: 680px;
     color: rgba(255, 255, 255, 0.85);
 }
 
 .site-hero .cta {
     display: inline-flex;
     align-items: center;
-    gap: 0.5rem;
-    background: #d7ff00;
+    gap: 0.6rem;
+    background: linear-gradient(135deg, #d7ff00 0%, #fff872 100%);
     color: #0f172a;
-    padding: 0.85rem 1.6rem;
+    padding: 0.95rem 1.8rem;
     border-radius: 999px;
     font-weight: 700;
     text-decoration: none;
-    transition: transform 0.2s ease, box-shadow 0.2s ease;
+    box-shadow: 0 18px 35px rgba(17, 20, 255, 0.35);
+    transition: transform 0.25s ease, box-shadow 0.25s ease;
 }
 
 .site-hero .cta:hover {
-    transform: translateY(-2px);
-    box-shadow: 0 20px 30px rgba(17, 20, 255, 0.25);
+    transform: translateY(-3px);
+    box-shadow: 0 25px 45px rgba(17, 20, 255, 0.35);
 }
 
 .site-content {
-    margin-top: 3rem;
-    background: rgba(255, 255, 255, 0.96);
-    border-radius: 1.75rem;
-    padding: 2.5rem;
-    box-shadow: 0 25px 50px rgba(15, 23, 42, 0.18);
+    margin-top: 3.5rem;
+    background: rgba(255, 255, 255, 0.95);
+    border-radius: 2rem;
+    padding: 2.75rem;
+    box-shadow: 0 35px 70px rgba(15, 23, 42, 0.22);
 }
 
 .site-footer {
-    margin-top: 2.5rem;
+    margin-top: 3rem;
     text-align: center;
-    color: rgba(255, 255, 255, 0.65);
+    color: rgba(255, 255, 255, 0.7);
     font-size: 0.9rem;
+    letter-spacing: 0.06em;
 }
 
 @media (max-width: 768px) {
+    .site-wrapper {
+        padding: 2.5rem 1.25rem 3.5rem;
+    }
+
     .site-hero {
-        padding: 2rem 1.5rem;
+        padding: 2.25rem 1.5rem;
     }
 
     .site-hero h1 {
-        font-size: 2.2rem;
+        font-size: 2.3rem;
     }
 
     .site-content {
-        padding: 1.75rem;
+        padding: 2rem;
+    }
+}
+
+@keyframes heroFloat {
+    0%, 100% {
+        transform: translateY(0);
+    }
+    50% {
+        transform: translateY(-20px);
     }
 }

--- a/wp-content/themes/codboost-finance/style.css
+++ b/wp-content/themes/codboost-finance/style.css
@@ -1,0 +1,104 @@
+/*
+Theme Name: Codboost Finance Portal
+Theme URI: https://codboost.pro/
+Author: Codboost
+Author URI: https://codboost.pro/
+Description: Tailored UI/UX theme for the Codboost money management experience.
+Version: 1.0.0
+License: GNU General Public License v2 or later
+License URI: http://www.gnu.org/licenses/gpl-2.0.html
+Text Domain: codboost-finance
+*/
+
+@import url('https://fonts.googleapis.com/css2?family=Inter:wght@400;600;700&display=swap');
+
+body {
+    margin: 0;
+    font-family: 'Inter', -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+    background: linear-gradient(135deg, #0f172a 0%, #1114ff 100%);
+    min-height: 100vh;
+    color: #0f172a;
+}
+
+a {
+    color: #d7ff00;
+}
+
+a:hover {
+    color: #fff;
+}
+
+.site-wrapper {
+    max-width: 1080px;
+    margin: 0 auto;
+    padding: 3rem 1.5rem 4rem;
+}
+
+.site-hero {
+    background: rgba(255, 255, 255, 0.08);
+    border-radius: 2rem;
+    padding: 2.5rem;
+    text-align: center;
+    color: #fff;
+    box-shadow: 0 30px 60px rgba(15, 23, 42, 0.45);
+}
+
+.site-hero h1 {
+    font-size: 2.8rem;
+    margin: 0 0 1rem;
+    letter-spacing: -0.02em;
+}
+
+.site-hero p {
+    font-size: 1.1rem;
+    margin: 0 auto 2rem;
+    max-width: 640px;
+    color: rgba(255, 255, 255, 0.85);
+}
+
+.site-hero .cta {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.5rem;
+    background: #d7ff00;
+    color: #0f172a;
+    padding: 0.85rem 1.6rem;
+    border-radius: 999px;
+    font-weight: 700;
+    text-decoration: none;
+    transition: transform 0.2s ease, box-shadow 0.2s ease;
+}
+
+.site-hero .cta:hover {
+    transform: translateY(-2px);
+    box-shadow: 0 20px 30px rgba(17, 20, 255, 0.25);
+}
+
+.site-content {
+    margin-top: 3rem;
+    background: rgba(255, 255, 255, 0.96);
+    border-radius: 1.75rem;
+    padding: 2.5rem;
+    box-shadow: 0 25px 50px rgba(15, 23, 42, 0.18);
+}
+
+.site-footer {
+    margin-top: 2.5rem;
+    text-align: center;
+    color: rgba(255, 255, 255, 0.65);
+    font-size: 0.9rem;
+}
+
+@media (max-width: 768px) {
+    .site-hero {
+        padding: 2rem 1.5rem;
+    }
+
+    .site-hero h1 {
+        font-size: 2.2rem;
+    }
+
+    .site-content {
+        padding: 1.75rem;
+    }
+}


### PR DESCRIPTION
## Summary
- build a Codboost Money Manager plugin with transaction logging, account/reason management, and localized analytics dashboards plus a gated shortcode for logged-in users
- add branded admin/front-end styling and Chart.js visualizations for cashflow and account distribution insights
- create a Codboost Finance Portal theme that provisions a dashboard page, injects the shortcode automatically, and wraps the experience in Codboost UI/UX polish

## Testing
- php -l codboost-plugin.php
- php -l wp-content/themes/codboost-finance/functions.php
- php -l wp-content/themes/codboost-finance/index.php
- php -l wp-content/themes/codboost-finance/page-money-manager.php
- php -l wp-content/themes/codboost-finance/header.php
- php -l wp-content/themes/codboost-finance/footer.php

------
https://chatgpt.com/codex/tasks/task_e_68e6903be1f0832bb1846e150a222ce0