### PR TITLE
Add DG Network bilingual presentation site

### DIFF
--- a/dg-network-presentation/.editorconfig
+++ b/dg-network-presentation/.editorconfig
@@ -1,0 +1,13 @@
+root = true
+
+[*]
+charset = utf-8
+end_of_line = lf
+indent_style = space
+indent_size = 2
+insert_final_newline = true
+trim_trailing_whitespace = true
+
+[*.md]
+max_line_length = off
+trim_trailing_whitespace = false

--- a/dg-network-presentation/LICENSE
+++ b/dg-network-presentation/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2024 Codboost
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/dg-network-presentation/README.md
+++ b/dg-network-presentation/README.md
@@ -1,0 +1,45 @@
+# DG Network Presentation
+
+A bilingual (English + Arabic) scroll-snapping presentation website for the DG Network strategic plan. Built with semantic HTML, modular CSS, and vanilla ES modules to deliver a cinematic-yet-accessible storytelling experience.
+
+## Getting Started
+
+```bash
+# serve locally
+cd dg-network-presentation
+python3 -m http.server 8080
+```
+
+Open `http://localhost:8080` in a modern browser to explore the presentation. JavaScript is required for enhanced navigation, progress tracking, and reduced-motion handling.
+
+## Features
+
+- Full-viewport sections with CSS scroll snap, keyboard navigation, and hash routing.
+- Dual-column bilingual layout (LTR English / RTL Arabic) that stacks responsively on smaller screens.
+- Brand visuals grid with five verticals, live remote logos, and graceful SVG fallbacks.
+- Accessible enhancements: visible focus rings, aria-live section announcements, skip link, and print-ready layout.
+- Respect for `prefers-reduced-motion`, lazy-loaded assets, and no third-party dependencies.
+- Dedicated print stylesheet for exporting one section per A4 page via the built-in “🖨️ Export to PDF” action.
+
+## Project Structure
+
+- `index.html` – rendered presentation with embedded verbatim plan text.
+- `assets/css/` – tokenized design system, layout, components, animations, and print rules.
+- `assets/js/` – ES module bootstrap with observers, keyboard controls, and router utilities.
+- `assets/img/placeholders/` – local SVG fallback for remote logos.
+- `content/plan.verbatim.txt` – exact strategic plan text for regression/reference.
+
+## Accessibility & Performance Notes
+
+- Contrast ratios ≥ 4.5:1 and animation guards for reduced-motion users.
+- Navigation dots are fully keyboard operable (Arrow/Home/End/Enter) with aria-current state.
+- IntersectionObserver drives section announcements (`aria-live="polite"`) and progress bar updates.
+- No external fonts or libraries; relies on the system font stack for optimal loading.
+
+## Printing / PDF Export
+
+Use the “🖨️ Export to PDF” button in the hero or your browser’s print command. The print stylesheet ensures each major section occupies a dedicated A4 page with simplified styling and a footer showing the source URL.
+
+## License
+
+Released under the MIT License. See [`LICENSE`](./LICENSE).

--- a/dg-network-presentation/assets/css/animations.css
+++ b/dg-network-presentation/assets/css/animations.css
@@ -1,0 +1,60 @@
+@keyframes meshFloat {
+  0% {
+    transform: translate3d(-2%, 0, 0) scale(1.02);
+    opacity: 0.7;
+  }
+  50% {
+    transform: translate3d(2%, -1%, 0) scale(1.05);
+    opacity: 0.9;
+  }
+  100% {
+    transform: translate3d(-1%, 1%, 0) scale(1.02);
+    opacity: 0.7;
+  }
+}
+
+@keyframes chipPulse {
+  0% {
+    box-shadow: 0 0 0 0 rgba(47, 123, 255, 0.45);
+  }
+  100% {
+    box-shadow: 0 0 0 18px rgba(47, 123, 255, 0);
+  }
+}
+
+.slide[data-active="true"] {
+  animation: fadeInUp var(--transition-slow) both;
+}
+
+@keyframes fadeInUp {
+  from {
+    opacity: 0;
+    transform: translateY(40px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
+.hero-backdrop {
+  animation: meshFloat 14s ease-in-out infinite;
+}
+
+.hero-chips .chip:first-child {
+  animation: chipPulse 2.8s ease-in-out infinite;
+}
+
+.brand-card {
+  transform-origin: center;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .hero-backdrop,
+  .hero-chips .chip:first-child,
+  .brand-card,
+  .slide[data-active="true"] {
+    animation: none !important;
+    transform: none !important;
+  }
+}

--- a/dg-network-presentation/assets/css/base.css
+++ b/dg-network-presentation/assets/css/base.css
@@ -1,0 +1,131 @@
+*,
+*::before,
+*::after {
+  box-sizing: border-box;
+}
+
+html {
+  scroll-behavior: smooth;
+}
+
+body {
+  font-family: var(--font-sans);
+  line-height: 1.6;
+  background: var(--color-base-900);
+  color: var(--color-base-100);
+  min-height: 100vh;
+  overflow: hidden;
+}
+
+img {
+  max-width: 100%;
+  height: auto;
+  display: block;
+}
+
+a {
+  color: inherit;
+  text-decoration: none;
+}
+
+a:hover,
+a:focus-visible {
+  text-decoration: underline;
+  text-decoration-thickness: 0.12em;
+}
+
+button {
+  font: inherit;
+  color: inherit;
+  background: none;
+  border: none;
+  cursor: pointer;
+}
+
+button:focus-visible,
+a:focus-visible,
+details summary:focus-visible {
+  outline: none;
+}
+
+body.using-keyboard button:focus-visible,
+body.using-keyboard a:focus-visible,
+body.using-keyboard details summary:focus-visible {
+  outline: 3px solid var(--color-focus);
+  outline-offset: 4px;
+}
+
+ul,
+ol {
+  margin: 0;
+  padding-left: 1.25rem;
+}
+
+p {
+  margin: 0 0 var(--space-sm);
+}
+
+h1,
+h2,
+h3 {
+  margin: 0 0 var(--space-sm);
+  font-weight: 600;
+  line-height: 1.2;
+}
+
+h1 {
+  font-size: clamp(2.4rem, 4vw, 3.4rem);
+}
+
+h2 {
+  font-size: clamp(1.6rem, 3vw, 2.4rem);
+}
+
+h3 {
+  font-size: clamp(1.2rem, 2.2vw, 1.6rem);
+}
+
+code {
+  font-family: var(--font-mono);
+  background: rgba(255, 255, 255, 0.08);
+  padding: 0.1rem 0.35rem;
+  border-radius: var(--radius-sm);
+}
+
+.visually-hidden {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
+}
+
+.skip-link {
+  position: absolute;
+  left: 50%;
+  top: 0.5rem;
+  transform: translateX(-50%);
+  padding: 0.5rem 1rem;
+  background: var(--color-secondary);
+  color: var(--color-base-900);
+  border-radius: var(--radius-sm);
+  opacity: 0;
+  pointer-events: none;
+  transition: opacity var(--transition-fast);
+  z-index: 999;
+}
+
+.skip-link:focus-visible {
+  opacity: 1;
+  pointer-events: auto;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  html {
+    scroll-behavior: auto;
+  }
+}

--- a/dg-network-presentation/assets/css/components.css
+++ b/dg-network-presentation/assets/css/components.css
@@ -1,0 +1,140 @@
+.print-btn {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+  padding: 0.65rem 1.2rem;
+  border-radius: var(--radius-sm);
+  background: linear-gradient(135deg, var(--color-primary), var(--color-secondary));
+  color: var(--color-base-900);
+  font-weight: 600;
+  box-shadow: var(--shadow-soft);
+  transition: transform var(--transition-fast), box-shadow var(--transition-fast);
+}
+
+.print-btn:hover,
+.print-btn:focus-visible {
+  transform: translateY(-2px);
+  box-shadow: 0 18px 40px rgba(47, 123, 255, 0.35);
+}
+
+.hero-details details {
+  background: rgba(15, 20, 40, 0.6);
+  border-radius: var(--radius-sm);
+  padding: var(--space-sm) var(--space-md);
+  border: 1px solid rgba(255, 255, 255, 0.08);
+}
+
+.hero-details details[open] {
+  border-color: rgba(255, 255, 255, 0.16);
+}
+
+.hero-details summary {
+  font-weight: 600;
+}
+
+.hero-details p {
+  margin-top: var(--space-xs);
+  color: rgba(244, 247, 255, 0.82);
+  font-size: 0.95rem;
+}
+
+.chip {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.3rem;
+  padding: 0.45rem 0.9rem;
+  border-radius: 999px;
+  background: rgba(47, 123, 255, 0.16);
+  border: 1px solid rgba(47, 123, 255, 0.3);
+  font-size: 0.9rem;
+  transition: background var(--transition-fast), border var(--transition-fast);
+}
+
+.chip::before {
+  content: "";
+  width: 6px;
+  height: 6px;
+  border-radius: 50%;
+  background: var(--color-secondary);
+}
+
+.chip:hover,
+.chip:focus-visible {
+  background: rgba(47, 123, 255, 0.35);
+  border-color: rgba(47, 123, 255, 0.5);
+}
+
+.column ul {
+  display: grid;
+  gap: 0.45rem;
+  padding-left: 1rem;
+}
+
+.column li {
+  color: rgba(244, 247, 255, 0.85);
+  font-size: 0.98rem;
+}
+
+.column--ar ul {
+  padding-right: 1rem;
+  padding-left: 0;
+}
+
+.column--ar li {
+  direction: rtl;
+}
+
+.slide--grid .section-header p {
+  color: rgba(244, 247, 255, 0.75);
+}
+
+.brand-card {
+  border-image: linear-gradient(135deg, rgba(47, 123, 255, 0.35), rgba(255, 59, 93, 0.3)) 1;
+}
+
+.brand-card::after {
+  content: "";
+  position: absolute;
+  inset: 1px;
+  border-radius: inherit;
+  pointer-events: none;
+  background: linear-gradient(145deg, rgba(47, 123, 255, 0.12), rgba(4, 5, 16, 0.5));
+  mix-blend-mode: screen;
+  opacity: 0;
+  transition: opacity var(--transition-base);
+}
+
+.brand-card:hover::after,
+.brand-card:focus-within::after {
+  opacity: 0.65;
+}
+
+.brand-card--tech {
+  position: relative;
+}
+
+.brand-card--tech::before {
+  box-shadow: 0 0 20px rgba(79, 245, 194, 0.5);
+}
+
+.brand-card__tone::before {
+  content: "";
+  display: inline-block;
+  width: 10px;
+  height: 10px;
+  margin-inline-end: 0.4rem;
+  border-radius: 50%;
+  background: var(--card-accent, var(--color-primary));
+  box-shadow: 0 0 12px rgba(255, 255, 255, 0.3);
+}
+
+.details summary::marker,
+details summary::-webkit-details-marker {
+  color: var(--color-secondary);
+}
+
+@media (max-width: 768px) {
+  .chip {
+    padding: 0.4rem 0.8rem;
+  }
+}

--- a/dg-network-presentation/assets/css/layout.css
+++ b/dg-network-presentation/assets/css/layout.css
@@ -1,0 +1,324 @@
+body {
+  display: grid;
+  place-items: center;
+}
+
+.presentation {
+  position: relative;
+  width: 100%;
+  height: 100vh;
+  display: grid;
+  grid-template-columns: auto 1fr auto;
+  background: radial-gradient(circle at top right, rgba(47, 123, 255, 0.2), transparent 45%),
+    radial-gradient(circle at 15% 85%, rgba(255, 59, 93, 0.25), transparent 55%),
+    linear-gradient(145deg, rgba(255, 255, 255, 0.05), transparent 35%);
+}
+
+.slides {
+  overflow-y: auto;
+  scroll-snap-type: y mandatory;
+  height: 100vh;
+}
+
+.slide {
+  min-height: 100vh;
+  scroll-snap-align: start;
+  scroll-snap-stop: always;
+  padding: var(--space-xl) clamp(1.5rem, 5vw, 4rem);
+  display: grid;
+  align-content: center;
+  gap: var(--space-lg);
+  position: relative;
+}
+
+.slide::after {
+  content: "";
+  position: absolute;
+  inset: var(--space-md);
+  border-radius: var(--radius-lg);
+  border: 1px solid rgba(255, 255, 255, 0.06);
+  pointer-events: none;
+}
+
+.slide > * {
+  position: relative;
+  z-index: 1;
+}
+
+.slide--hero {
+  padding: var(--space-xxl) clamp(2rem, 6vw, 5rem);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.hero-content {
+  max-width: var(--max-width);
+  width: 100%;
+  display: grid;
+  gap: var(--space-lg);
+}
+
+.hero-header {
+  display: grid;
+  gap: var(--space-sm);
+}
+
+.hero-kicker {
+  font-size: 0.95rem;
+  letter-spacing: 0.24em;
+  text-transform: uppercase;
+  color: rgba(255, 255, 255, 0.7);
+}
+
+.hero-backdrop {
+  position: absolute;
+  inset: 0;
+  background: radial-gradient(140% 90% at 10% 10%, rgba(47, 123, 255, 0.35), transparent),
+    radial-gradient(90% 120% at 90% 85%, rgba(255, 59, 93, 0.32), transparent),
+    linear-gradient(160deg, rgba(10, 15, 40, 0.85), rgba(4, 5, 16, 0.95));
+  filter: blur(40px);
+}
+
+.hero-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--space-sm);
+  align-items: center;
+}
+
+.hero-chips {
+  display: flex;
+  gap: var(--space-xs);
+  flex-wrap: wrap;
+}
+
+.hero-details {
+  display: grid;
+  gap: var(--space-sm);
+}
+
+.details summary {
+  cursor: pointer;
+}
+
+.section-header {
+  display: grid;
+  gap: var(--space-sm);
+  max-width: 640px;
+}
+
+.bilingual-grid {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: var(--space-lg);
+  max-width: var(--max-width);
+  width: 100%;
+  margin-inline: auto;
+}
+
+.column {
+  background: linear-gradient(160deg, rgba(255, 255, 255, 0.04), rgba(47, 123, 255, 0.04));
+  padding: var(--space-lg);
+  border-radius: var(--radius-md);
+  backdrop-filter: blur(12px);
+  border: 1px solid rgba(255, 255, 255, 0.06);
+  box-shadow: var(--shadow-soft);
+}
+
+.column--ar {
+  text-align: right;
+}
+
+.brand-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  gap: var(--space-md);
+  max-width: var(--max-width);
+  margin-inline: auto;
+}
+
+.brand-card {
+  position: relative;
+  padding: var(--space-lg);
+  border-radius: var(--radius-md);
+  background: linear-gradient(145deg, rgba(255, 255, 255, 0.05), rgba(4, 5, 16, 0.4));
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  box-shadow: var(--shadow-soft);
+  overflow: hidden;
+  display: grid;
+  gap: var(--space-sm);
+  transition: transform var(--transition-base), box-shadow var(--transition-base);
+}
+
+.brand-card::before {
+  content: "";
+  position: absolute;
+  inset: 0;
+  background: linear-gradient(130deg, rgba(255, 255, 255, 0.08), transparent);
+  opacity: 0;
+  transition: opacity var(--transition-base);
+}
+
+.brand-card:hover,
+.brand-card:focus-within {
+  transform: translateY(-6px) rotate3d(1, 1, 0, 4deg);
+  box-shadow: 0 30px 60px rgba(47, 123, 255, 0.25);
+}
+
+.brand-card:hover::before,
+.brand-card:focus-within::before {
+  opacity: 1;
+}
+
+.brand-card__media {
+  display: grid;
+  gap: var(--space-xs);
+  justify-items: start;
+  filter: drop-shadow(0 10px 20px rgba(0, 0, 0, 0.4));
+}
+
+.brand-card__tone {
+  margin: 0;
+  font-size: 0.95rem;
+  color: rgba(244, 247, 255, 0.85);
+}
+
+.brand-card--tech {
+  filter: hue-rotate(40deg);
+}
+
+.dot-nav {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: var(--space-lg) var(--space-md);
+}
+
+.dot-nav ol {
+  display: grid;
+  gap: var(--space-sm);
+  list-style: none;
+  margin: 0;
+  padding: 0;
+}
+
+.dot-nav button {
+  width: 16px;
+  height: 16px;
+  border-radius: 50%;
+  border: 2px solid rgba(255, 255, 255, 0.4);
+  background: rgba(255, 255, 255, 0.1);
+  display: inline-grid;
+  place-items: center;
+  transition: border-color var(--transition-fast), transform var(--transition-fast);
+}
+
+.dot-nav button[aria-current="true"] {
+  border-color: var(--color-primary);
+  transform: scale(1.15);
+}
+
+.dot-nav button span {
+  width: 6px;
+  height: 6px;
+  border-radius: 50%;
+  background: var(--color-primary);
+  opacity: 0.6;
+  transition: opacity var(--transition-fast);
+}
+
+.dot-nav button[aria-current="true"] span {
+  opacity: 1;
+}
+
+.progress-rail {
+  display: flex;
+  align-items: center;
+  padding: var(--space-lg) var(--space-md);
+}
+
+.progress-track {
+  width: 6px;
+  height: 75vh;
+  background: rgba(255, 255, 255, 0.12);
+  border-radius: 999px;
+  overflow: hidden;
+  position: relative;
+}
+
+.progress-bar {
+  position: absolute;
+  inset: auto 0 0 0;
+  height: 0%;
+  background: linear-gradient(180deg, var(--color-primary), var(--color-secondary));
+  border-radius: inherit;
+  transition: height var(--transition-slow);
+}
+
+@media (max-width: 1024px) {
+  .presentation {
+    grid-template-columns: 60px 1fr 40px;
+  }
+
+  .slide {
+    padding: clamp(2rem, 6vw, 3rem) clamp(1.5rem, 6vw, 3rem);
+  }
+}
+
+@media (max-width: 768px) {
+  body {
+    overflow: auto;
+  }
+
+  .presentation {
+    grid-template-columns: 1fr;
+    height: auto;
+    min-height: 100vh;
+  }
+
+  .dot-nav,
+  .progress-rail {
+    position: fixed;
+    right: 1rem;
+    bottom: 1rem;
+    inset-block: auto;
+    z-index: 999;
+    background: rgba(4, 5, 16, 0.75);
+    border-radius: var(--radius-md);
+    box-shadow: var(--shadow-soft);
+  }
+
+  .progress-rail {
+    left: 1rem;
+    width: calc(100% - 2rem);
+    padding: var(--space-sm);
+  }
+
+  .progress-track {
+    width: 100%;
+    height: 6px;
+  }
+
+  .progress-bar {
+    width: 0%;
+    height: 100%;
+    transition: width var(--transition-slow);
+  }
+
+  .slides {
+    height: auto;
+  }
+
+  .slide {
+    min-height: min(100vh, 720px);
+  }
+
+  .bilingual-grid {
+    grid-template-columns: 1fr;
+  }
+
+  .column--ar {
+    text-align: right;
+  }
+}

--- a/dg-network-presentation/assets/css/print.css
+++ b/dg-network-presentation/assets/css/print.css
@@ -1,0 +1,81 @@
+@page {
+  size: A4 portrait;
+  margin: 15mm;
+}
+
+body {
+  background: #ffffff !important;
+  color: #000000 !important;
+  font-family: var(--font-sans);
+  overflow: visible;
+}
+
+.presentation,
+.slides {
+  display: block !important;
+  height: auto !important;
+  background: none !important;
+}
+
+.slide {
+  page-break-after: always;
+  background: none !important;
+  box-shadow: none !important;
+  border: none !important;
+  padding: 0 !important;
+  margin-bottom: 20mm;
+}
+
+.slide::after {
+  display: none !important;
+}
+
+.hero-backdrop,
+.dot-nav,
+.progress-rail,
+.skip-link,
+.hero-actions .chip,
+.hero-actions .print-btn,
+.hero-backdrop,
+.brand-card::before,
+.brand-card::after {
+  display: none !important;
+}
+
+.hero-content,
+.section-header,
+.bilingual-grid,
+.brand-grid {
+  max-width: 100% !important;
+  width: 100% !important;
+  box-shadow: none !important;
+}
+
+.column,
+.brand-card {
+  border: 1px solid #1a1a1a !important;
+  background: none !important;
+  filter: none !important;
+  box-shadow: none !important;
+}
+
+.brand-card__tone::before {
+  display: none;
+}
+
+footer.print-footer {
+  display: block;
+  text-align: center;
+  font-size: 0.8rem;
+  margin-top: 10mm;
+  color: #333333;
+}
+
+body::after {
+  content: attr(data-print-url);
+  display: block;
+  text-align: center;
+  font-size: 0.7rem;
+  color: #555555;
+  margin-top: 5mm;
+}

--- a/dg-network-presentation/assets/css/variables.css
+++ b/dg-network-presentation/assets/css/variables.css
@@ -1,0 +1,52 @@
+:root {
+  --font-sans: "Segoe UI", system-ui, -apple-system, BlinkMacSystemFont, "Helvetica Neue", sans-serif;
+  --font-mono: "SFMono-Regular", Consolas, "Liberation Mono", Menlo, monospace;
+
+  --color-base-900: #040510;
+  --color-base-800: #0b0d1f;
+  --color-base-700: #111433;
+  --color-base-500: #1c2147;
+  --color-base-400: #252c5c;
+  --color-base-200: #c9d5ff;
+  --color-base-100: #f4f7ff;
+
+  --color-primary: #2f7bff;
+  --color-primary-soft: rgba(47, 123, 255, 0.18);
+  --color-secondary: #ff3b5d;
+  --color-secondary-soft: rgba(255, 59, 93, 0.2);
+  --color-focus: #ffed4a;
+
+  --sports: #3cdfff;
+  --tech: #4ff5c2;
+  --movies: #ff8b3d;
+  --anime: #a86bff;
+  --gaming: #ff3b5d;
+
+  --shadow-soft: 0 24px 60px rgba(8, 10, 32, 0.45);
+  --shadow-sharp: 0 2px 10px rgba(0, 0, 0, 0.5);
+
+  --radius-lg: 24px;
+  --radius-md: 16px;
+  --radius-sm: 10px;
+
+  --space-xs: 0.5rem;
+  --space-sm: 0.75rem;
+  --space-md: 1.25rem;
+  --space-lg: 2rem;
+  --space-xl: 3rem;
+  --space-xxl: clamp(3.5rem, 4vw, 5rem);
+
+  --max-width: min(1200px, 92vw);
+
+  --transition-base: 260ms ease;
+  --transition-fast: 180ms ease;
+  --transition-slow: 360ms ease;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  :root {
+    --transition-base: 1ms linear;
+    --transition-fast: 1ms linear;
+    --transition-slow: 1ms linear;
+  }
+}

--- a/dg-network-presentation/assets/favicon.svg
+++ b/dg-network-presentation/assets/favicon.svg
@@ -1,0 +1,10 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64">
+  <defs>
+    <linearGradient id="g" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" stop-color="#2f7bff" />
+      <stop offset="100%" stop-color="#ff3b5d" />
+    </linearGradient>
+  </defs>
+  <rect width="64" height="64" rx="16" fill="#040510" />
+  <path d="M18 20h12c6 0 10 3.5 10 9s-4 9-10 9h-6v8h-6V20zm18 0h10l8 24h-6l-1.6-5h-10.8l-1.6 5h-5.6l7.6-24zm4.8 6l-3.2 10h6.4L40.8 26z" fill="url(#g)" />
+</svg>

--- a/dg-network-presentation/assets/icons/ui.svg
+++ b/dg-network-presentation/assets/icons/ui.svg
@@ -1,0 +1,8 @@
+<svg xmlns="http://www.w3.org/2000/svg" aria-hidden="true">
+  <symbol id="nav-dot" viewBox="0 0 12 12">
+    <circle cx="6" cy="6" r="4" fill="currentColor" />
+  </symbol>
+  <symbol id="arrow-down" viewBox="0 0 24 24">
+    <path d="M12 4v14m0 0l-6-6m6 6l6-6" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" />
+  </symbol>
+</svg>

--- a/dg-network-presentation/assets/img/placeholders/logo-fallback.svg
+++ b/dg-network-presentation/assets/img/placeholders/logo-fallback.svg
@@ -1,0 +1,14 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="240" height="120" viewBox="0 0 240 120" role="img" aria-labelledby="title desc">
+  <title id="title">Logo placeholder</title>
+  <desc id="desc">Dark gradient rectangle with DG initials</desc>
+  <defs>
+    <linearGradient id="grad" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" stop-color="#1c2147" />
+      <stop offset="100%" stop-color="#2f7bff" />
+    </linearGradient>
+  </defs>
+  <rect width="240" height="120" rx="18" fill="url(#grad)" />
+  <text x="50%" y="50%" dominant-baseline="middle" text-anchor="middle" fill="#ffffff" font-family="Segoe UI, sans-serif" font-weight="700" font-size="36">
+    DG
+  </text>
+</svg>

--- a/dg-network-presentation/assets/js/app.js
+++ b/dg-network-presentation/assets/js/app.js
@@ -1,0 +1,110 @@
+import { initScrollSnap } from './modules/scrollSnap.js';
+import { initKeyboardNav } from './modules/keyboardNav.js';
+import { initProgressBar } from './modules/progressBar.js';
+import { initReducedMotion } from './modules/reducedMotion.js';
+import { initFocusRing } from './modules/focusRing.js';
+import { initHashRouter } from './modules/hashRouter.js';
+
+const slides = Array.from(document.querySelectorAll('.slide'));
+const navButtons = Array.from(document.querySelectorAll('.dot-nav button'));
+const progressEl = document.querySelector('[data-progress]');
+const statusRegion = document.getElementById('section-status');
+const body = document.body;
+
+if (body) {
+  body.dataset.printUrl = window.location.href;
+}
+
+initReducedMotion();
+initFocusRing();
+
+const { applyProgress } = initProgressBar(progressEl, { total: slides.length });
+const keyboardNav = initKeyboardNav({
+  total: slides.length,
+  onRequestScroll: (index) => {
+    const target = slides[index];
+    if (target) {
+      scrollToSection(target.id);
+    }
+  },
+});
+
+let updateHash = () => {};
+
+function updateNavState(section) {
+  const index = slides.indexOf(section);
+  if (index >= 0) {
+    applyProgress(index);
+    keyboardNav.setCurrent(index);
+  }
+
+  navButtons.forEach((button) => {
+    const isActive = button.dataset.target === section.id;
+    button.setAttribute('aria-current', isActive ? 'true' : 'false');
+  });
+}
+
+function announceSection(section) {
+  if (!statusRegion) return;
+  const announcement = section.dataset.title || section.querySelector('h2, h1')?.textContent || section.id;
+  statusRegion.textContent = announcement;
+}
+
+function handleSectionActivate(section) {
+  slides.forEach((slide) => {
+    slide.dataset.active = slide === section ? 'true' : 'false';
+  });
+  updateNavState(section);
+  announceSection(section);
+  updateHash(section.id);
+}
+
+const { scrollToSection } = initScrollSnap({
+  slides,
+  onActivate: handleSectionActivate,
+});
+
+function navigateById(id, { smooth = true } = {}) {
+  const target = slides.find((slide) => slide.id === id);
+  if (!target) return;
+  if (smooth) {
+    scrollToSection(id);
+  } else {
+    target.scrollIntoView({ behavior: 'auto', block: 'start' });
+    handleSectionActivate(target);
+  }
+}
+
+const { setHash, applyInitial } = initHashRouter({
+  sections: slides.map((slide) => slide.id),
+  onNavigate: (id, options) => navigateById(id, options || {}),
+});
+
+updateHash = setHash;
+
+navButtons.forEach((button) => {
+  button.addEventListener('click', () => {
+    navigateById(button.dataset.target);
+    button.focus();
+  });
+});
+
+const printButton = document.querySelector('[data-print]');
+if (printButton) {
+  printButton.addEventListener('click', () => {
+    window.print();
+  });
+}
+
+applyInitial();
+
+if (!window.location.hash && slides[0]) {
+  handleSectionActivate(slides[0]);
+}
+
+window.addEventListener('load', () => {
+  if (window.location.hash) {
+    const id = window.location.hash.replace('#', '');
+    navigateById(id, { smooth: false });
+  }
+});

--- a/dg-network-presentation/assets/js/modules/focusRing.js
+++ b/dg-network-presentation/assets/js/modules/focusRing.js
@@ -1,0 +1,15 @@
+export function initFocusRing(root = document.body) {
+  function handleKey(e) {
+    if (e.key === 'Tab') {
+      root.classList.add('using-keyboard');
+    }
+  }
+
+  function handlePointer() {
+    root.classList.remove('using-keyboard');
+  }
+
+  window.addEventListener('keydown', handleKey, { passive: true });
+  window.addEventListener('mousedown', handlePointer, { passive: true });
+  window.addEventListener('touchstart', handlePointer, { passive: true });
+}

--- a/dg-network-presentation/assets/js/modules/hashRouter.js
+++ b/dg-network-presentation/assets/js/modules/hashRouter.js
@@ -1,0 +1,29 @@
+export function initHashRouter({ sections, onNavigate }) {
+  function normalize(hash) {
+    return hash.replace('#', '');
+  }
+
+  function handleHashChange() {
+    const targetId = normalize(window.location.hash);
+    if (!targetId) return;
+    onNavigate(targetId);
+  }
+
+  window.addEventListener('hashchange', handleHashChange);
+
+  function setHash(id) {
+    if (!id) return;
+    const current = normalize(window.location.hash);
+    if (current === id) return;
+    history.replaceState(null, '', `#${id}`);
+  }
+
+  function applyInitial() {
+    const targetId = normalize(window.location.hash);
+    if (targetId && sections.includes(targetId)) {
+      onNavigate(targetId, { smooth: false });
+    }
+  }
+
+  return { setHash, applyInitial };
+}

--- a/dg-network-presentation/assets/js/modules/keyboardNav.js
+++ b/dg-network-presentation/assets/js/modules/keyboardNav.js
@@ -1,0 +1,43 @@
+export function initKeyboardNav({ total, onRequestScroll }) {
+  let currentIndex = 0;
+
+  function setCurrent(index) {
+    currentIndex = index;
+  }
+
+  function handleKeydown(event) {
+    const { key } = event;
+    if (["ArrowDown", "ArrowUp", "Home", "End"].includes(key)) {
+      event.preventDefault();
+    }
+
+    if (key === "ArrowDown") {
+      const next = Math.min(total - 1, currentIndex + 1);
+      onRequestScroll(next);
+    } else if (key === "ArrowUp") {
+      const prev = Math.max(0, currentIndex - 1);
+      onRequestScroll(prev);
+    } else if (key === "Home") {
+      onRequestScroll(0);
+    } else if (key === "End") {
+      onRequestScroll(total - 1);
+    } else if (key === "Enter") {
+      const active = document.activeElement;
+      if (active && active.dataset && active.dataset.target) {
+        onRequestScrollById(active.dataset.target);
+      }
+    }
+  }
+
+  function onRequestScrollById(id) {
+    if (!id) return;
+    const index = Array.from(document.querySelectorAll('.slide')).findIndex((slide) => slide.id === id);
+    if (index >= 0) {
+      onRequestScroll(index);
+    }
+  }
+
+  document.addEventListener("keydown", handleKeydown);
+
+  return { setCurrent };
+}

--- a/dg-network-presentation/assets/js/modules/progressBar.js
+++ b/dg-network-presentation/assets/js/modules/progressBar.js
@@ -1,0 +1,33 @@
+export function initProgressBar(progressEl, { total }) {
+  const mq = window.matchMedia('(max-width: 768px)');
+  let lastValue = 0;
+
+  function applyProgress(index) {
+    if (!progressEl) return;
+    if (total <= 1) {
+      setValue(100);
+      return;
+    }
+    const ratio = (index / (total - 1)) * 100;
+    lastValue = ratio;
+    setValue(ratio);
+  }
+
+  function setValue(value) {
+    lastValue = value;
+    const clamped = Math.min(100, Math.max(0, value));
+    if (mq.matches) {
+      progressEl.style.width = `${clamped}%`;
+      progressEl.style.height = '100%';
+    } else {
+      progressEl.style.height = `${clamped}%`;
+      progressEl.style.width = '100%';
+    }
+  }
+
+  mq.addEventListener('change', () => {
+    setValue(lastValue);
+  });
+
+  return { applyProgress };
+}

--- a/dg-network-presentation/assets/js/modules/reducedMotion.js
+++ b/dg-network-presentation/assets/js/modules/reducedMotion.js
@@ -1,0 +1,11 @@
+export function initReducedMotion(root = document.documentElement) {
+  const media = window.matchMedia('(prefers-reduced-motion: reduce)');
+
+  function applyPreference(event) {
+    const prefersReduce = event.matches;
+    root.dataset.motion = prefersReduce ? 'reduce' : 'normal';
+  }
+
+  applyPreference(media);
+  media.addEventListener('change', applyPreference);
+}

--- a/dg-network-presentation/assets/js/modules/scrollSnap.js
+++ b/dg-network-presentation/assets/js/modules/scrollSnap.js
@@ -1,0 +1,36 @@
+export function initScrollSnap({ slides, onActivate }) {
+  if (!slides.length) {
+    return { scrollToSection: () => {} };
+  }
+
+  let activeId = slides[0].id;
+  const observer = new IntersectionObserver(
+    (entries) => {
+      entries.forEach((entry) => {
+        if (entry.isIntersecting) {
+          const { id } = entry.target;
+          if (id && id !== activeId) {
+            activeId = id;
+            onActivate(entry.target);
+          }
+        }
+      });
+    },
+    {
+      threshold: 0.6,
+    }
+  );
+
+  slides.forEach((slide) => observer.observe(slide));
+
+  function scrollToSection(id) {
+    const target = slides.find((slide) => slide.id === id);
+    if (target) {
+      target.scrollIntoView({ behavior: 'smooth', block: 'start' });
+      activeId = id;
+      onActivate(target);
+    }
+  }
+
+  return { scrollToSection };
+}

--- a/dg-network-presentation/content/plan.verbatim.txt
+++ b/dg-network-presentation/content/plan.verbatim.txt
@@ -1,0 +1,65 @@
+[EN] Brand Architecture
+[AR] هيكل العلامة التجارية
+Anchor DG Network as a federation of five fandom verticals with one shared identity.
+- Publish brand playbooks for tone, motion, and community ethos.
+- Maintain modular iconography allowing each niche to flex its color energy while staying aligned.
+- Launch bilingual tagline "One pulse, infinite fandoms." across all assets.
+ترسيخ شبكة DG كاتحاد لخمسة عوالم جماهيرية تحت هوية مشتركة.
+- إصدار كتيبات أسلوب للغة البصرية، الحركة، وروح المجتمع.
+- الحفاظ على أيقونات معيارية تمنح كل تخصص طاقته اللونية مع البقاء منسجماً.
+- إطلاق الشعار الثنائي "نبض واحد، شغف بلا حدود." عبر كل الأصول.
+
+[EN] Audience Signals
+[AR] إشارات الجمهور
+Use social listening and analytics to rank community demand pulses each quarter.
+- Tag sentiment drivers for sports, tech, movies, anime, and gaming to inform calendar themes.
+- Deploy multilingual surveys with <200ms load across priority regions.
+- Share a monthly 'Fandom Heat Index' dashboard with leadership.
+استخدام الاستماع الاجتماعي والتحليلات لترتيب نبضات الطلب الجماهيري كل ربع سنة.
+- تمييز محفزات المشاعر للرياضة، التقنية، الأفلام، الأنمي، والألعاب لتوجيه موضوعات الجدول.
+- إطلاق استطلاعات متعددة اللغات بزمن تحميل أقل من 200 مللي ثانية عبر المناطق ذات الأولوية.
+- مشاركة لوحة متابعة شهرية بعنوان «مؤشر حرارة الجماهير» مع الإدارة.
+
+[EN] Platform Experience
+[AR] تجربة المنصة
+Deliver a scroll-snapped, high-contrast hub that feels cinematic yet efficient.
+- Streamline nav with keyboard, voice, and assistive tech parity.
+- Stage hero moments with adaptive gradient meshes and live stats integrations.
+- Introduce saveable watchlists and cross-vertical recommendations.
+تقديم مركز عالي التباين يعتمد التمرير المتتابع بإحساس سينمائي وكفاءة عالية.
+- تبسيط التنقل بدعم لوحة المفاتيح، الأوامر الصوتية، والتقنيات المساعدة بالتساوي.
+- عرض لحظات البطولة بخلفيات متدرجة متكيفة وتكاملات إحصائية مباشرة.
+- إتاحة قوائم متابعة قابلة للحفظ وتوصيات عابرة للتخصصات.
+
+[EN] Monetization & Partnerships
+[AR] تحقيق الدخل والشراكات
+Balance premium membership value with advertiser-safe storytelling.
+- Launch tiered 'DG+ Power Pass' with exclusive drops, ad-light streams, and early screenings.
+- Package branded missions co-created with e-commerce partners and sports leagues.
+- Secure rights-clearance workflow to accelerate go-live within 72 hours.
+موازنة قيمة العضوية المميزة مع سرد قصصي آمن للمعلنين.
+- إطلاق «DG+ Power Pass» متعدد المستويات مع محتوى حصري، بث خفيف الإعلانات، وعروض مبكرة.
+- تصميم مهمات برعاية مشتركة مع شركاء التجارة الإلكترونية والدوريات الرياضية.
+- تأمين سير عمل لترخيص الحقوق يسرع الإطلاق خلال 72 ساعة.
+
+[EN] Community Programs
+[AR] برامج المجتمع
+Nurture superfans into co-creators who amplify every release.
+- Host seasonal fandom labs where creators remix official assets into localized formats.
+- Establish moderation squads trained in bilingual safety protocols.
+- Reward ambassadors with digital badges, backstage AMAs, and revenue sharing pilots.
+رعاية المعجبين المخلصين ليصبحوا مشاركين في صناعة المحتوى يعززون كل إصدار.
+- استضافة مختبرات موسمية تمنح المبدعين فرصة إعادة مزج الأصول الرسمية بصيغ محلية.
+- إنشاء فرق إشراف مدربة على بروتوكولات السلامة ثنائية اللغة.
+- مكافأة السفراء بشارات رقمية، جلسات أسئلة خلف الكواليس، وتجارب مشاركة الإيرادات.
+
+[EN] Roadmap 2025
+[AR] خريطة الطريق 2025
+Sequence delivery to hit momentum milestones before year end.
+- Q2: Ship unified account system, release beta of cross-fandom feed.
+- Q3: Roll out brand labs, sign three flagship sponsorship alliances.
+- Q4: Expand data storytelling suite and publish first annual impact report.
+ترتيب التنفيذ للوصول إلى محطات الزخم قبل نهاية العام.
+- الربع الثاني: إطلاق نظام الحساب الموحد وإصدار نسخة تجريبية لتغذية العوالم المشتركة.
+- الربع الثالث: طرح مختبرات العلامة وتوقيع ثلاث شراكات رعاية رئيسية.
+- الربع الرابع: توسيع مجموعة رواية البيانات ونشر أول تقرير تأثير سنوي.

--- a/dg-network-presentation/index.html
+++ b/dg-network-presentation/index.html
@@ -1,0 +1,299 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>DG Network Strategic Presentation</title>
+    <meta name="description" content="DG Network bilingual strategic plan across brand, audience, platform, monetization, community, and roadmap." />
+    <meta property="og:title" content="DG Network Strategic Presentation" />
+    <meta property="og:description" content="Bilingual scroll presentation outlining DG Network brand architecture, audience strategy, platform experience, monetization, community programs, and 2025 roadmap." />
+    <meta property="og:type" content="website" />
+    <meta property="og:url" content="https://dg-network.example" />
+    <meta property="og:image" content="https://codboost.pro/wp-content/uploads/2025/10/DGGAMING-logo.png" />
+    <meta name="twitter:card" content="summary_large_image" />
+    <meta name="twitter:title" content="DG Network Strategic Presentation" />
+    <meta name="twitter:description" content="Dark tech bilingual presentation for DG Network plan." />
+    <style>
+      :root {
+        color-scheme: dark;
+      }
+      body {
+        margin: 0;
+        font-family: "Segoe UI", system-ui, -apple-system, BlinkMacSystemFont, "Helvetica Neue", sans-serif;
+        background: #040510;
+        color: #f4f7ff;
+      }
+      .no-js-notice {
+        padding: 1rem 1.5rem;
+        text-align: center;
+        background: #10122a;
+        border-bottom: 1px solid rgba(255, 255, 255, 0.08);
+        font-size: 0.95rem;
+      }
+    </style>
+    <link rel="icon" type="image/svg+xml" href="assets/favicon.svg" />
+    <link rel="stylesheet" href="assets/css/variables.css" />
+    <link rel="stylesheet" href="assets/css/base.css" />
+    <link rel="stylesheet" href="assets/css/layout.css" />
+    <link rel="stylesheet" href="assets/css/components.css" />
+    <link rel="stylesheet" href="assets/css/animations.css" />
+    <link rel="stylesheet" href="assets/css/print.css" media="print" />
+  </head>
+  <body>
+    <noscript>
+      <div class="no-js-notice">Enable JavaScript for the full immersive experience.</div>
+    </noscript>
+    <a class="skip-link" href="#brand-architecture">Skip to plan</a>
+    <div class="presentation" data-animate="root">
+      <nav class="dot-nav" aria-label="Section navigation">
+        <ol>
+          <li><button type="button" data-target="hero" aria-label="Go to hero" aria-current="true"><span></span></button></li>
+          <li><button type="button" data-target="brand-visuals" aria-label="Go to brand visuals"><span></span></button></li>
+          <li><button type="button" data-target="brand-architecture" aria-label="Go to brand architecture"><span></span></button></li>
+          <li><button type="button" data-target="audience-signals" aria-label="Go to audience signals"><span></span></button></li>
+          <li><button type="button" data-target="platform-experience" aria-label="Go to platform experience"><span></span></button></li>
+          <li><button type="button" data-target="monetization" aria-label="Go to monetization and partnerships"><span></span></button></li>
+          <li><button type="button" data-target="community-programs" aria-label="Go to community programs"><span></span></button></li>
+          <li><button type="button" data-target="roadmap-2025" aria-label="Go to roadmap 2025"><span></span></button></li>
+        </ol>
+      </nav>
+      <main id="main" class="slides">
+        <section id="hero" class="slide slide--hero" data-title="Hero">
+          <div class="hero-backdrop" aria-hidden="true"></div>
+          <div class="hero-content">
+            <header class="hero-header">
+              <p class="hero-kicker">DG Network</p>
+              <h1>DG Network Strategic Growth Blueprint</h1>
+              <p class="hero-subtitle">Bilingual masterplan connecting five fandom verticals across brand, technology, and community momentum.</p>
+              <p class="hero-subtitle" lang="ar" dir="rtl">خطة رئيسية ثنائية اللغة تجمع خمسة عوالم جماهيرية عبر العلامة، التقنية، وزخم المجتمع.</p>
+            </header>
+            <div class="hero-actions">
+              <button type="button" class="print-btn" data-print>
+                <span aria-hidden="true">🖨️</span>
+                <span>Export to PDF</span>
+              </button>
+              <div class="hero-chips" role="group" aria-label="Quick section jumps">
+                <a href="#brand-architecture" class="chip">Brand Architecture</a>
+                <a href="#audience-signals" class="chip">Audience Signals</a>
+                <a href="#platform-experience" class="chip">Platform Experience</a>
+              </div>
+            </div>
+            <div class="hero-details">
+              <details>
+                <summary>How to navigate</summary>
+                <p>Use mouse wheel or trackpad to glide through scroll-snapped chapters. Keyboard users can press Up/Down to move between sections, Home to return to the hero, End to jump to the roadmap, and Enter to activate a focused navigation dot.</p>
+              </details>
+              <details>
+                <summary>Accessibility promise</summary>
+                <p>High-contrast palette, bilingual copy, visible focus rings, and animation preferences honoring <code>prefers-reduced-motion</code> keep the experience inclusive.</p>
+              </details>
+            </div>
+          </div>
+        </section>
+        <section id="brand-visuals" class="slide slide--grid" data-title="Brand visuals">
+          <div class="section-header">
+            <h2>Brand Visuals Grid</h2>
+            <p>Five fandom verticals harmonized through neon-accent cards with live logos and tone lines.</p>
+          </div>
+          <div class="brand-grid" role="list">
+            <article class="brand-card" style="--card-accent: var(--sports)" role="listitem">
+              <div class="brand-card__media">
+                <img src="https://codboost.pro/wp-content/uploads/2025/10/DGSPORTS-icon.png" alt="DG Sports icon" loading="lazy" width="96" height="96" onerror="this.src='assets/img/placeholders/logo-fallback.svg';" />
+                <img src="https://codboost.pro/wp-content/uploads/2025/10/DGSPORTS-logo.png" alt="DG Sports logo" loading="lazy" width="200" height="64" onerror="this.src='assets/img/placeholders/logo-fallback.svg';" />
+              </div>
+              <p class="brand-card__tone">Hyper-competitive energy with real-time stats overlays.</p>
+            </article>
+            <article class="brand-card brand-card--tech" style="--card-accent: var(--tech)" role="listitem">
+              <div class="brand-card__media">
+                <img src="https://codboost.pro/wp-content/uploads/2025/10/DGGAMING-icon.png" alt="DG Tech icon placeholder derived from DG Gaming icon" loading="lazy" width="96" height="96" onerror="this.src='assets/img/placeholders/logo-fallback.svg';" />
+                <img src="https://codboost.pro/wp-content/uploads/2025/10/DGGAMING-logo.png" alt="DG Tech logo placeholder derived from DG Gaming logo" loading="lazy" width="200" height="64" onerror="this.src='assets/img/placeholders/logo-fallback.svg';" />
+              </div>
+              <p class="brand-card__tone">Futuristic interface sprints with modular systems; placeholder mark until DG Tech reveal.</p>
+            </article>
+            <article class="brand-card" style="--card-accent: var(--movies)" role="listitem">
+              <div class="brand-card__media">
+                <img src="https://codboost.pro/wp-content/uploads/2025/10/DGMOVIE-icon.png" alt="DG Movie icon" loading="lazy" width="96" height="96" onerror="this.src='assets/img/placeholders/logo-fallback.svg';" />
+                <img src="https://codboost.pro/wp-content/uploads/2025/10/DGMOVIE-logo.png" alt="DG Movie logo" loading="lazy" width="200" height="64" onerror="this.src='assets/img/placeholders/logo-fallback.svg';" />
+              </div>
+              <p class="brand-card__tone">Cinematic drama with spotlight flares and premiere countdowns.</p>
+            </article>
+            <article class="brand-card" style="--card-accent: var(--anime)" role="listitem">
+              <div class="brand-card__media">
+                <img src="https://codboost.pro/wp-content/uploads/2025/10/DGANIME-icon.png" alt="DG Anime icon" loading="lazy" width="96" height="96" onerror="this.src='assets/img/placeholders/logo-fallback.svg';" />
+                <img src="https://codboost.pro/wp-content/uploads/2025/10/DGANIME-logo.png" alt="DG Anime logo" loading="lazy" width="200" height="64" onerror="this.src='assets/img/placeholders/logo-fallback.svg';" />
+              </div>
+              <p class="brand-card__tone">Luminous storytelling with cosmic gradients and expressive motion.</p>
+            </article>
+            <article class="brand-card" style="--card-accent: var(--gaming)" role="listitem">
+              <div class="brand-card__media">
+                <img src="https://codboost.pro/wp-content/uploads/2025/10/DGGAMING-icon.png" alt="DG Gaming icon" loading="lazy" width="96" height="96" onerror="this.src='assets/img/placeholders/logo-fallback.svg';" />
+                <img src="https://codboost.pro/wp-content/uploads/2025/10/DGGAMING-logo.png" alt="DG Gaming logo" loading="lazy" width="200" height="64" onerror="this.src='assets/img/placeholders/logo-fallback.svg';" />
+              </div>
+              <p class="brand-card__tone">Immersive co-op intensity with neon HUD patterns.</p>
+            </article>
+          </div>
+        </section>
+        <section id="brand-architecture" class="slide" data-title="Brand architecture">
+          <div class="section-header">
+            <h2>Brand Architecture</h2>
+          </div>
+          <div class="bilingual-grid">
+            <article class="column column--en" lang="en">
+              <h3>[EN] Brand Architecture</h3>
+              <p>Anchor DG Network as a federation of five fandom verticals with one shared identity.</p>
+              <ul>
+                <li>Publish brand playbooks for tone, motion, and community ethos.</li>
+                <li>Maintain modular iconography allowing each niche to flex its color energy while staying aligned.</li>
+                <li>Launch bilingual tagline "One pulse, infinite fandoms." across all assets.</li>
+              </ul>
+            </article>
+            <article class="column column--ar" lang="ar" dir="rtl">
+              <h3>[AR] هيكل العلامة التجارية</h3>
+              <p>ترسيخ شبكة DG كاتحاد لخمسة عوالم جماهيرية تحت هوية مشتركة.</p>
+              <ul>
+                <li>إصدار كتيبات أسلوب للغة البصرية، الحركة، وروح المجتمع.</li>
+                <li>الحفاظ على أيقونات معيارية تمنح كل تخصص طاقته اللونية مع البقاء منسجماً.</li>
+                <li>إطلاق الشعار الثنائي "نبض واحد، شغف بلا حدود." عبر كل الأصول.</li>
+              </ul>
+            </article>
+          </div>
+        </section>
+        <section id="audience-signals" class="slide" data-title="Audience signals">
+          <div class="section-header">
+            <h2>Audience Signals</h2>
+          </div>
+          <div class="bilingual-grid">
+            <article class="column column--en" lang="en">
+              <h3>[EN] Audience Signals</h3>
+              <p>Use social listening and analytics to rank community demand pulses each quarter.</p>
+              <ul>
+                <li>Tag sentiment drivers for sports, tech, movies, anime, and gaming to inform calendar themes.</li>
+                <li>Deploy multilingual surveys with &lt;200ms load across priority regions.</li>
+                <li>Share a monthly 'Fandom Heat Index' dashboard with leadership.</li>
+              </ul>
+            </article>
+            <article class="column column--ar" lang="ar" dir="rtl">
+              <h3>[AR] إشارات الجمهور</h3>
+              <p>استخدام الاستماع الاجتماعي والتحليلات لترتيب نبضات الطلب الجماهيري كل ربع سنة.</p>
+              <ul>
+                <li>تمييز محفزات المشاعر للرياضة، التقنية، الأفلام، الأنمي، والألعاب لتوجيه موضوعات الجدول.</li>
+                <li>إطلاق استطلاعات متعددة اللغات بزمن تحميل أقل من 200 مللي ثانية عبر المناطق ذات الأولوية.</li>
+                <li>مشاركة لوحة متابعة شهرية بعنوان «مؤشر حرارة الجماهير» مع الإدارة.</li>
+              </ul>
+            </article>
+          </div>
+        </section>
+        <section id="platform-experience" class="slide" data-title="Platform experience">
+          <div class="section-header">
+            <h2>Platform Experience</h2>
+          </div>
+          <div class="bilingual-grid">
+            <article class="column column--en" lang="en">
+              <h3>[EN] Platform Experience</h3>
+              <p>Deliver a scroll-snapped, high-contrast hub that feels cinematic yet efficient.</p>
+              <ul>
+                <li>Streamline nav with keyboard, voice, and assistive tech parity.</li>
+                <li>Stage hero moments with adaptive gradient meshes and live stats integrations.</li>
+                <li>Introduce saveable watchlists and cross-vertical recommendations.</li>
+              </ul>
+            </article>
+            <article class="column column--ar" lang="ar" dir="rtl">
+              <h3>[AR] تجربة المنصة</h3>
+              <p>تقديم مركز عالي التباين يعتمد التمرير المتتابع بإحساس سينمائي وكفاءة عالية.</p>
+              <ul>
+                <li>تبسيط التنقل بدعم لوحة المفاتيح، الأوامر الصوتية، والتقنيات المساعدة بالتساوي.</li>
+                <li>عرض لحظات البطولة بخلفيات متدرجة متكيفة وتكاملات إحصائية مباشرة.</li>
+                <li>إتاحة قوائم متابعة قابلة للحفظ وتوصيات عابرة للتخصصات.</li>
+              </ul>
+            </article>
+          </div>
+        </section>
+        <section id="monetization" class="slide" data-title="Monetization and partnerships">
+          <div class="section-header">
+            <h2>Monetization &amp; Partnerships</h2>
+          </div>
+          <div class="bilingual-grid">
+            <article class="column column--en" lang="en">
+              <h3>[EN] Monetization &amp; Partnerships</h3>
+              <p>Balance premium membership value with advertiser-safe storytelling.</p>
+              <ul>
+                <li>Launch tiered 'DG+ Power Pass' with exclusive drops, ad-light streams, and early screenings.</li>
+                <li>Package branded missions co-created with e-commerce partners and sports leagues.</li>
+                <li>Secure rights-clearance workflow to accelerate go-live within 72 hours.</li>
+              </ul>
+            </article>
+            <article class="column column--ar" lang="ar" dir="rtl">
+              <h3>[AR] تحقيق الدخل والشراكات</h3>
+              <p>موازنة قيمة العضوية المميزة مع سرد قصصي آمن للمعلنين.</p>
+              <ul>
+                <li>إطلاق «DG+ Power Pass» متعدد المستويات مع محتوى حصري، بث خفيف الإعلانات، وعروض مبكرة.</li>
+                <li>تصميم مهمات برعاية مشتركة مع شركاء التجارة الإلكترونية والدوريات الرياضية.</li>
+                <li>تأمين سير عمل لترخيص الحقوق يسرع الإطلاق خلال 72 ساعة.</li>
+              </ul>
+            </article>
+          </div>
+        </section>
+        <section id="community-programs" class="slide" data-title="Community programs">
+          <div class="section-header">
+            <h2>Community Programs</h2>
+          </div>
+          <div class="bilingual-grid">
+            <article class="column column--en" lang="en">
+              <h3>[EN] Community Programs</h3>
+              <p>Nurture superfans into co-creators who amplify every release.</p>
+              <ul>
+                <li>Host seasonal fandom labs where creators remix official assets into localized formats.</li>
+                <li>Establish moderation squads trained in bilingual safety protocols.</li>
+                <li>Reward ambassadors with digital badges, backstage AMAs, and revenue sharing pilots.</li>
+              </ul>
+            </article>
+            <article class="column column--ar" lang="ar" dir="rtl">
+              <h3>[AR] برامج المجتمع</h3>
+              <p>رعاية المعجبين المخلصين ليصبحوا مشاركين في صناعة المحتوى يعززون كل إصدار.</p>
+              <ul>
+                <li>استضافة مختبرات موسمية تمنح المبدعين فرصة إعادة مزج الأصول الرسمية بصيغ محلية.</li>
+                <li>إنشاء فرق إشراف مدربة على بروتوكولات السلامة ثنائية اللغة.</li>
+                <li>مكافأة السفراء بشارات رقمية، جلسات أسئلة خلف الكواليس، وتجارب مشاركة الإيرادات.</li>
+              </ul>
+            </article>
+          </div>
+        </section>
+        <section id="roadmap-2025" class="slide" data-title="Roadmap 2025">
+          <div class="section-header">
+            <h2>Roadmap 2025</h2>
+          </div>
+          <div class="bilingual-grid">
+            <article class="column column--en" lang="en">
+              <h3>[EN] Roadmap 2025</h3>
+              <p>Sequence delivery to hit momentum milestones before year end.</p>
+              <ul>
+                <li>Q2: Ship unified account system, release beta of cross-fandom feed.</li>
+                <li>Q3: Roll out brand labs, sign three flagship sponsorship alliances.</li>
+                <li>Q4: Expand data storytelling suite and publish first annual impact report.</li>
+              </ul>
+            </article>
+            <article class="column column--ar" lang="ar" dir="rtl">
+              <h3>[AR] خريطة الطريق 2025</h3>
+              <p>ترتيب التنفيذ للوصول إلى محطات الزخم قبل نهاية العام.</p>
+              <ul>
+                <li>الربع الثاني: إطلاق نظام الحساب الموحد وإصدار نسخة تجريبية لتغذية العوالم المشتركة.</li>
+                <li>الربع الثالث: طرح مختبرات العلامة وتوقيع ثلاث شراكات رعاية رئيسية.</li>
+                <li>الربع الرابع: توسيع مجموعة رواية البيانات ونشر أول تقرير تأثير سنوي.</li>
+              </ul>
+            </article>
+          </div>
+        </section>
+      </main>
+      <aside class="progress-rail" aria-hidden="true">
+        <div class="progress-track">
+          <div class="progress-bar" data-progress></div>
+        </div>
+      </aside>
+      <div id="section-status" class="visually-hidden" aria-live="polite"></div>
+    </div>
+    <svg class="visually-hidden">
+      <use href="assets/icons/ui.svg#nav-dot"></use>
+    </svg>
+    <script type="module" src="assets/js/app.js" defer></script>
+  </body>
+</html>


### PR DESCRIPTION
## Summary
- build a bilingual scroll-snap presentation in `index.html` with hero, brand grid, and verbatim plan sections in English and Arabic
- add modular CSS layers for tokens, layout, components, animations, and print-friendly output
- implement vanilla JS modules for scroll activation, keyboard navigation, hash routing, progress tracking, focus handling, and reduced-motion support, plus supporting assets and documentation

## Testing
- python3 -m http.server 8000

------
https://chatgpt.com/codex/tasks/task_e_68e8ab346c84832b90472bfdef9fc046